### PR TITLE
Add DataArgumentShouldBeLast rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ With that said, I recommend [trying them out](#try-it-out) to help you decide.
 
 ## Provided rules
 
-- [`DataArgumentShouldBeLast`](https://package.elm-lang.org/packages/jfmengels/elm-review-code-style/1.1.4/DataArgumentShouldBeLast) - Reports REPLACEME.
+- [`DataArgumentShouldBeLast`](https://package.elm-lang.org/packages/jfmengels/elm-review-code-style/1.1.4/DataArgumentShouldBeLast) - Reports functions where the data argument is not the last argument.
 - [🔧 `NoSimpleLetBody`](https://package.elm-lang.org/packages/jfmengels/elm-review-code-style/1.1.4/NoSimpleLetBody/ "Provides automatic fixes") - Reports when a let expression's body is a simple reference to a value declared in the let expression.
 - [🔧 `NoUnnecessaryTrailingUnderscore`](https://package.elm-lang.org/packages/jfmengels/elm-review-code-style/1.1.4/NoUnnecessaryTrailingUnderscore/ "Provides automatic fixes") - Reports unnecessary or suboptimal trailing underscores in variable names.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ With that said, I recommend [trying them out](#try-it-out) to help you decide.
 
 ## Provided rules
 
+- [`DataArgumentShouldBeLast`](https://package.elm-lang.org/packages/jfmengels/elm-review-code-style/1.1.4/DataArgumentShouldBeLast) - Reports REPLACEME.
 - [🔧 `NoSimpleLetBody`](https://package.elm-lang.org/packages/jfmengels/elm-review-code-style/1.1.4/NoSimpleLetBody/ "Provides automatic fixes") - Reports when a let expression's body is a simple reference to a value declared in the let expression.
 - [🔧 `NoUnnecessaryTrailingUnderscore`](https://package.elm-lang.org/packages/jfmengels/elm-review-code-style/1.1.4/NoUnnecessaryTrailingUnderscore/ "Provides automatic fixes") - Reports unnecessary or suboptimal trailing underscores in variable names.
 
@@ -24,6 +25,7 @@ With that said, I recommend [trying them out](#try-it-out) to help you decide.
 ```elm
 module ReviewConfig exposing (config)
 
+import DataArgumentShouldBeLast
 import NoSimpleLetBody
 import NoUnnecessaryTrailingUnderscore
 import Review.Rule exposing (Rule)
@@ -31,6 +33,7 @@ import Review.Rule exposing (Rule)
 config : List Rule
 config =
     [ NoUnnecessaryTrailingUnderscore.rule
+    , DataArgumentShouldBeLast.rule
     , NoSimpleLetBody.rule
     ]
 ```

--- a/elm.json
+++ b/elm.json
@@ -5,6 +5,7 @@
     "license": "BSD-3-Clause",
     "version": "1.1.4",
     "exposed-modules": [
+        "DataArgumentShouldBeLast",
         "NoSimpleLetBody",
         "NoUnnecessaryTrailingUnderscore"
     ],

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -11,6 +11,7 @@ when inside the directory containing this file.
 
 -}
 
+import DataArgumentShouldBeLast
 import NoSimpleLetBody
 import NoUnnecessaryTrailingUnderscore
 import Review.Rule exposing (Rule)
@@ -19,5 +20,6 @@ import Review.Rule exposing (Rule)
 config : List Rule
 config =
     [ NoUnnecessaryTrailingUnderscore.rule
+    , DataArgumentShouldBeLast.rule
     , NoSimpleLetBody.rule
     ]

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -195,7 +195,7 @@ createFix context nbOfArguments argPosition argIndex nextArgumentRange returnTyp
                     }
                 , moveCode context
                     { from = rangeToMove
-                    , to = { row = 5, column = 18 }
+                    , to = lastArgPosition.end
                     }
                 ]
 

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -374,9 +374,9 @@ isNotDataLast type_ lookupTable =
 isTypeEqual : ModuleNameLookupTable -> Bool -> Node TypeAnnotation -> Node TypeAnnotation -> Bool
 isTypeEqual lookupTable isTopLevel node returnType =
     case Node.value node of
-        TypeAnnotation.Typed (Node _ ( _, nameA )) _ ->
+        TypeAnnotation.Typed (Node _ ( _, nameA )) nodesA ->
             case Node.value returnType of
-                TypeAnnotation.Typed (Node _ ( _, nameB )) _ ->
+                TypeAnnotation.Typed (Node _ ( _, nameB )) nodesB ->
                     if nameA /= nameB then
                         False
 
@@ -385,8 +385,17 @@ isTypeEqual lookupTable isTopLevel node returnType =
                             Just moduleNameA ->
                                 case ModuleNameLookupTable.moduleNameFor lookupTable returnType of
                                     Just moduleNameB ->
-                                        -- It's okay if the type variables are different
-                                        moduleNameA == moduleNameB
+                                        if moduleNameA == moduleNameB then
+                                            if isTopLevel then
+                                                True
+                                                -- It's okay if the type variables are different at the top-level
+
+                                            else
+                                                List.map2 (isTypeEqual lookupTable False) nodesA nodesB
+                                                    |> List.all identity
+
+                                        else
+                                            False
 
                                     Nothing ->
                                         False

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -174,7 +174,7 @@ declarationVisitor node context =
                                     }
                                     argPosition
                                     [ Fix.removeRange argTypeRange
-                                    , Fix.insertAt { row = 4, column = 25 } " Model ->"
+                                    , Fix.insertAt (Node.range returnType).start (context.extractSourceCode argTypeRange)
                                     , Fix.removeRange { start = { row = 5, column = 8 }, end = { row = 5, column = 14 } }
                                     , Fix.insertAt { row = 5, column = 18 } "model "
                                     ]

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -13,7 +13,7 @@ import Elm.Syntax.Expression as Expression exposing (Expression)
 import Elm.Syntax.Module as Module
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (Pattern)
-import Elm.Syntax.Range as Range exposing (Location, Range)
+import Elm.Syntax.Range exposing (Location, Range)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (RecordField, TypeAnnotation)
 import Review.Fix as Fix exposing (Fix)
 import Review.ModuleNameLookupTable as ModuleNameLookupTable exposing (ModuleNameLookupTable)

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -364,7 +364,7 @@ isNotDataLast type_ lookupTable =
                         Nothing
 
                     else
-                        case findAndGiveElementAndItsPrevious (\arg -> isTypeEqual lookupTable True arg returnType) 0 firstArg rest of
+                        case findAndGiveElementAndItsPrevious (\arg -> isTypeEqual lookupTable True arg returnType) (List.length rest - 1) firstArg rest of
                             Just ( arg, argIndex, nextElement ) ->
                                 Just
                                     { argPosition = Node.range arg
@@ -533,7 +533,7 @@ findAndGiveElementAndItsPrevious predicate index previous list =
                 Just ( x, index, previous )
 
             else
-                findAndGiveElementAndItsPrevious predicate (index + 1) x xs
+                findAndGiveElementAndItsPrevious predicate (index - 1) x xs
 
 
 listAtIndex : Int -> List (Node a) -> Location -> Maybe Range

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -136,6 +136,8 @@ isNotDataLast type_ =
     Nothing
 
 
+{-| Returned arguments are in the opposite order.
+-}
 getReturnType : Node TypeAnnotation -> List TypeAnnotation -> { returnType : TypeAnnotation, arguments : List TypeAnnotation }
 getReturnType type_ argsAcc =
     case Node.value type_ of

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -10,7 +10,7 @@ import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Range as Range exposing (Range)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (RecordField, TypeAnnotation)
-import Review.ModuleNameLookupTable exposing (ModuleNameLookupTable)
+import Review.ModuleNameLookupTable as ModuleNameLookupTable exposing (ModuleNameLookupTable)
 import Review.Rule as Rule exposing (Rule)
 import Set exposing (Set)
 
@@ -200,10 +200,15 @@ getArguments type_ lookupTable argsAcc =
             getArguments return_ lookupTable ((Node (Node.range arg) <| Node.value <| removeRange arg) :: argsAcc)
 
         TypeAnnotation.Typed _ _ ->
-            Just
-                { returnType = Node.value (removeRange type_)
-                , arguments = argsAcc
-                }
+            case ModuleNameLookupTable.moduleNameFor lookupTable type_ of
+                Just [] ->
+                    Just
+                        { returnType = Node.value (removeRange type_)
+                        , arguments = argsAcc
+                        }
+
+                _ ->
+                    Nothing
 
         _ ->
             Nothing

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -413,11 +413,10 @@ isTypeEqual lookupTable node returnType =
                 _ ->
                     False
 
-        TypeAnnotation.GenericType _ ->
-            -- It's okay if the type variables are different
+        TypeAnnotation.GenericType a ->
             case Node.value returnType of
-                TypeAnnotation.GenericType _ ->
-                    True
+                TypeAnnotation.GenericType b ->
+                    a == b
 
                 _ ->
                     False

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -6,7 +6,7 @@ module DataArgumentShouldBeLast exposing (rule)
 
 -}
 
-import Elm.Syntax.Expression exposing (Expression)
+import Elm.Syntax.Declaration exposing (Declaration)
 import Elm.Syntax.Node as Node exposing (Node)
 import Review.Rule as Rule exposing (Rule)
 
@@ -70,7 +70,7 @@ type alias ModuleContext =
 moduleVisitor : Rule.ModuleRuleSchema schema ModuleContext -> Rule.ModuleRuleSchema { schema | hasAtLeastOneVisitor : () } ModuleContext
 moduleVisitor schema =
     schema
-        |> Rule.withExpressionEnterVisitor expressionVisitor
+        |> Rule.withDeclarationEnterVisitor declarationVisitor
 
 
 initialProjectContext : ProjectContext
@@ -99,8 +99,8 @@ foldProjectContexts new previous =
     {}
 
 
-expressionVisitor : Node Expression -> ProjectContext -> ( List (Rule.Error {}), ProjectContext )
-expressionVisitor node context =
+declarationVisitor : Node Declaration -> ProjectContext -> ( List (Rule.Error {}), ProjectContext )
+declarationVisitor node context =
     case Node.value node of
         _ ->
             ( [], context )

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -397,7 +397,10 @@ getArguments type_ lookupTable argsAcc =
 
         TypeAnnotation.Record fields ->
             Just
-                { returnType = Node (Node.range type_) (TypeAnnotation.Record fields)
+                { returnType =
+                    fields
+                        |> TypeAnnotation.Record
+                        |> Node (Node.range type_)
                 , arguments = argsAcc
                 }
 

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -395,9 +395,9 @@ getArguments type_ lookupTable argsAcc =
                 _ ->
                     Nothing
 
-        TypeAnnotation.Record _ ->
+        TypeAnnotation.Record fields ->
             Just
-                { returnType = Node (Node.range type_) <| Node.value <| removeRange type_
+                { returnType = Node (Node.range type_) (TypeAnnotation.Record fields)
                 , arguments = argsAcc
                 }
 

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -254,8 +254,7 @@ expressionVisitor node context =
                                     )
                             in
                             if List.length arguments == error.nbOfArguments then
-                                -- TODO Add fixes
-                                case createFixesForFunctionCall arguments of
+                                case createFixesForFunctionCall error arguments of
                                     [] ->
                                         cancelFixesAndReportError ()
 
@@ -299,7 +298,8 @@ expressionVisitor node context =
             ( [], context )
 
 
-createFixesForFunctionCall arguments =
+createFixesForFunctionCall : PendingError -> List (Node Expression) -> List Fix
+createFixesForFunctionCall error arguments =
     -- TODO Create a fix for the function call.
     -- We probably need to get more information like the position of the argument to move
     -- That needs to come from the PendingError, but we don't store it there yet.

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -179,3 +179,17 @@ removeRange node =
 removeRangeFromRecordField : Node RecordField -> Node RecordField
 removeRangeFromRecordField (Node _ ( Node _ property, value )) =
     Node Range.emptyRange ( Node Range.emptyRange property, removeRange value )
+
+
+find : (a -> Bool) -> List a -> Maybe a
+find predicate list =
+    case list of
+        [] ->
+            Nothing
+
+        x :: xs ->
+            if predicate x then
+                Just x
+
+            else
+                find predicate xs

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -237,6 +237,9 @@ declarationVisitor node context =
 expressionVisitor : Node Expression -> ModuleContext -> ( List (Rule.Error {}), ModuleContext )
 expressionVisitor node context =
     case Node.value node of
+        Expression.Application ((Node _ (Expression.FunctionOrValue [] name)) :: arguments) ->
+            ( [], context )
+
         Expression.FunctionOrValue [] name ->
             case Dict.get name context.errors of
                 Just error ->

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -114,8 +114,12 @@ type alias ProjectContext =
 type alias ModuleContext =
     { lookupTable : ModuleNameLookupTable
     , extractSourceCode : Range -> String
-    , errors : List (Rule.Error {})
+    , errors : List PendingError
     }
+
+
+type alias PendingError =
+    Rule.Error {}
 
 
 moduleVisitor : Rule.ModuleRuleSchema schema ModuleContext -> Rule.ModuleRuleSchema { schema | hasAtLeastOneVisitor : () } ModuleContext

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -160,6 +160,11 @@ declarationVisitor node context =
                 Just (Node _ type_) ->
                     case isNotDataLast type_.typeAnnotation context.lookupTable of
                         Just { argPosition, nextArgumentRange, returnType } ->
+                            let
+                                argTypeRange : Range
+                                argTypeRange =
+                                    { start = argPosition.start, end = nextArgumentRange.start }
+                            in
                             ( [ Rule.errorWithFix
                                     { message = "The data argument should be last"
                                     , details =
@@ -168,7 +173,7 @@ declarationVisitor node context =
                                         ]
                                     }
                                     argPosition
-                                    [ Fix.removeRange { start = argPosition.start, end = nextArgumentRange.start }
+                                    [ Fix.removeRange argTypeRange
                                     , Fix.insertAt { row = 4, column = 25 } " Model ->"
                                     , Fix.removeRange { start = { row = 5, column = 8 }, end = { row = 5, column = 14 } }
                                     , Fix.insertAt { row = 5, column = 18 } "model "

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -244,6 +244,13 @@ expressionVisitor node context =
                 Just error ->
                     case ModuleNameLookupTable.moduleNameFor context.lookupTable node of
                         Just [] ->
+                            let
+                                cancelFixesAndReportError : () -> ( List (Rule.Error {}), ModuleContext )
+                                cancelFixesAndReportError () =
+                                    ( [ createError { range = error.range, fixes = [] } ]
+                                    , { context | errors = Dict.remove name context.errors }
+                                    )
+                            in
                             if List.length arguments == error.nbOfArguments then
                                 -- TODO Add fixes
                                 ( []
@@ -254,9 +261,7 @@ expressionVisitor node context =
                                 )
 
                             else
-                                ( [ createError { range = error.range, fixes = [] } ]
-                                , { context | errors = Dict.remove name context.errors }
-                                )
+                                cancelFixesAndReportError ()
 
                         _ ->
                             ( [], context )

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -114,8 +114,11 @@ declarationVisitor node context =
                     case isNotDataLast type_.typeAnnotation context.lookupTable of
                         Just { argPosition, returnType } ->
                             ( [ Rule.error
-                                    { message = "REPLACEME"
-                                    , details = [ "REPLACEME" ]
+                                    { message = "The data argument should be last"
+                                    , details =
+                                        [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for isntance easy to pipe multiple functions working on the same type using `|>`."
+                                        , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
+                                        ]
                                     }
                                     argPosition
                               ]

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -253,12 +253,17 @@ expressionVisitor node context =
                             in
                             if List.length arguments == error.nbOfArguments then
                                 -- TODO Add fixes
-                                ( []
-                                , { context
-                                    | rangeToIgnore = Just fnRange
-                                    , errors = Dict.insert name { error | fixes = error.fixes } context.errors
-                                  }
-                                )
+                                case [] of
+                                    [] ->
+                                        cancelFixesAndReportError ()
+
+                                    _ ->
+                                        ( []
+                                        , { context
+                                            | rangeToIgnore = Just fnRange
+                                            , errors = Dict.insert name { error | fixes = error.fixes } context.errors
+                                          }
+                                        )
 
                             else
                                 cancelFixesAndReportError ()

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -159,7 +159,7 @@ declarationVisitor node context =
             case signature of
                 Just (Node _ type_) ->
                     case isNotDataLast type_.typeAnnotation context.lookupTable of
-                        Just { argPosition, nextArgumentRange, returnType } ->
+                        Just { argPosition, argIndex, nextArgumentRange, returnType } ->
                             ( [ Rule.errorWithFix
                                     { message = "The data argument should be last"
                                     , details =
@@ -168,7 +168,7 @@ declarationVisitor node context =
                                         ]
                                     }
                                     argPosition
-                                    (createFix context argPosition nextArgumentRange returnType)
+                                    (createFix context argPosition argIndex nextArgumentRange returnType)
                               ]
                             , context
                             )
@@ -183,8 +183,8 @@ declarationVisitor node context =
             ( [], context )
 
 
-createFix : ModuleContext -> Range -> Range -> Node d -> List Fix
-createFix context argPosition nextArgumentRange returnType =
+createFix : ModuleContext -> Range -> Int -> Range -> Node d -> List Fix
+createFix context argPosition argIndex nextArgumentRange returnType =
     let
         argTypeRange : Range
         argTypeRange =
@@ -197,7 +197,7 @@ createFix context argPosition nextArgumentRange returnType =
     ]
 
 
-isNotDataLast : Node TypeAnnotation -> ModuleNameLookupTable -> Maybe { argPosition : Range, nextArgumentRange : Range, returnType : Node TypeAnnotation }
+isNotDataLast : Node TypeAnnotation -> ModuleNameLookupTable -> Maybe { argPosition : Range, argIndex : Int, nextArgumentRange : Range, returnType : Node TypeAnnotation }
 isNotDataLast type_ lookupTable =
     case getArguments type_ lookupTable [] of
         Nothing ->
@@ -214,6 +214,7 @@ isNotDataLast type_ lookupTable =
                             Just ( arg, nextElement ) ->
                                 Just
                                     { argPosition = Node.range arg
+                                    , argIndex = 0
                                     , nextArgumentRange = Node.range nextElement
                                     , returnType = returnType
                                     }

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -269,7 +269,7 @@ finalEvaluation moduleContext =
         moduleContext.errors
 
 
-createError : PendingError -> Rule.Error {}
+createError : { a | range : Range, fixes : List Fix } -> Rule.Error {}
 createError { range, fixes } =
     Rule.errorWithFix
         { message = "The data argument should be last"

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -105,7 +105,14 @@ declarationVisitor node context =
         Declaration.FunctionDeclaration { signature, declaration } ->
             case signature of
                 Just type_ ->
-                    ( [], context )
+                    ( [ Rule.error
+                            { message = "REPLACEME"
+                            , details = [ "REPLACEME" ]
+                            }
+                            (Node.range node)
+                      ]
+                    , context
+                    )
 
                 Nothing ->
                     ( [], context )

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -186,7 +186,7 @@ declarationVisitor node context =
 
 createFix : ModuleContext -> Int -> Range -> Int -> Range -> Node d -> List (Node Pattern) -> List Fix
 createFix context nbOfArguments argPosition argIndex nextArgumentRange returnType arguments =
-    case listAtIndex nbOfArguments argIndex arguments of
+    case listAtIndex argIndex arguments of
         Just { rangeToMove } ->
             List.concat
                 [ moveCode context
@@ -307,8 +307,8 @@ findAndGiveElementAndItsPrevious predicate index previous list =
                 findAndGiveElementAndItsPrevious predicate (index + 1) x xs
 
 
-listAtIndex : Int -> Int -> List (Node a) -> Maybe { rangeToMove : Range }
-listAtIndex nbOfArguments index list =
+listAtIndex : Int -> List (Node a) -> Maybe { rangeToMove : Range }
+listAtIndex index list =
     case list of
         [] ->
             Nothing
@@ -327,4 +327,4 @@ listAtIndex nbOfArguments index list =
                         Nothing
 
             else
-                listAtIndex nbOfArguments (index - 1) xs
+                listAtIndex (index - 1) xs

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -350,11 +350,11 @@ isNotDataLast type_ lookupTable =
         Just { returnType, arguments } ->
             case arguments of
                 firstArg :: rest ->
-                    if isTypeEqual lookupTable firstArg returnType then
+                    if isTypeEqual lookupTable True firstArg returnType then
                         Nothing
 
                     else
-                        case findAndGiveElementAndItsPrevious (\arg -> isTypeEqual lookupTable arg returnType) 0 firstArg rest of
+                        case findAndGiveElementAndItsPrevious (\arg -> isTypeEqual lookupTable True arg returnType) 0 firstArg rest of
                             Just ( arg, argIndex, nextElement ) ->
                                 Just
                                     { argPosition = Node.range arg
@@ -371,8 +371,8 @@ isNotDataLast type_ lookupTable =
                     Nothing
 
 
-isTypeEqual : ModuleNameLookupTable -> Node TypeAnnotation -> Node TypeAnnotation -> Bool
-isTypeEqual lookupTable node returnType =
+isTypeEqual : ModuleNameLookupTable -> Bool -> Node TypeAnnotation -> Node TypeAnnotation -> Bool
+isTypeEqual lookupTable isTopLevel node returnType =
     case Node.value node of
         TypeAnnotation.Typed (Node _ ( _, nameA )) _ ->
             case Node.value returnType of
@@ -432,7 +432,7 @@ isTypeEqual lookupTable node returnType =
         TypeAnnotation.Tupled nodesA ->
             case Node.value returnType of
                 TypeAnnotation.Tupled nodesB ->
-                    List.map2 (isTypeEqual lookupTable) nodesA nodesB
+                    List.map2 (isTypeEqual lookupTable False) nodesA nodesB
                         |> List.all identity
 
                 _ ->
@@ -442,8 +442,8 @@ isTypeEqual lookupTable node returnType =
             -- It's okay if the type variables are different
             case Node.value returnType of
                 TypeAnnotation.FunctionTypeAnnotation inputB outputB ->
-                    isTypeEqual lookupTable inputA inputB
-                        && isTypeEqual lookupTable outputA outputB
+                    isTypeEqual lookupTable False inputA inputB
+                        && isTypeEqual lookupTable False outputA outputB
 
                 _ ->
                     False
@@ -456,7 +456,7 @@ areFieldsEqual lookupTable fieldsA fieldsB =
             (\(Node _ ( nameA, a )) (Node _ ( nameB, b )) ->
                 \() ->
                     if Node.value nameA == Node.value nameB then
-                        isTypeEqual lookupTable a b
+                        isTypeEqual lookupTable False a b
 
                     else
                         False

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -159,7 +159,7 @@ declarationVisitor node context =
             case signature of
                 Just (Node _ type_) ->
                     case isNotDataLast type_.typeAnnotation context.lookupTable of
-                        Just { argPosition, returnType } ->
+                        Just { argPosition, nextArgumentRange, returnType } ->
                             ( [ Rule.errorWithFix
                                     { message = "The data argument should be last"
                                     , details =
@@ -187,7 +187,7 @@ declarationVisitor node context =
             ( [], context )
 
 
-isNotDataLast : Node TypeAnnotation -> ModuleNameLookupTable -> Maybe { argPosition : Range, returnType : Node TypeAnnotation }
+isNotDataLast : Node TypeAnnotation -> ModuleNameLookupTable -> Maybe { argPosition : Range, nextArgumentRange : Range, returnType : Node TypeAnnotation }
 isNotDataLast type_ lookupTable =
     case getArguments type_ lookupTable [] of
         Nothing ->
@@ -204,6 +204,7 @@ isNotDataLast type_ lookupTable =
                             Just ( arg, nextElement ) ->
                                 Just
                                     { argPosition = Node.range arg
+                                    , nextArgumentRange = Node.range nextElement
                                     , returnType = returnType
                                     }
 

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -198,7 +198,7 @@ declarationVisitor node context =
 
 finalEvaluation : ModuleContext -> List (Rule.Error {})
 finalEvaluation moduleContext =
-    []
+    moduleContext.errors
 
 
 createFix : ModuleContext -> Int -> Range -> Int -> Range -> Node d -> Location -> List (Node Pattern) -> List Fix

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -10,6 +10,7 @@ import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Range as Range exposing (Range)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (RecordField, TypeAnnotation)
+import Review.Fix as Fix
 import Review.ModuleNameLookupTable as ModuleNameLookupTable exposing (ModuleNameLookupTable)
 import Review.Rule as Rule exposing (Rule)
 
@@ -101,6 +102,7 @@ rule =
             }
         -- Enable this if modules need to get information from other modules
         -- |> Rule.withContextFromImportedModules
+        |> Rule.providesFixesForProjectRule
         |> Rule.fromProjectRuleSchema
 
 
@@ -166,7 +168,11 @@ declarationVisitor node context =
                                         ]
                                     }
                                     argPosition
-                                    []
+                                    [ Fix.removeRange { start = { row = 4, column = 10 }, end = { row = 4, column = 19 } }
+                                    , Fix.insertAt { row = 4, column = 25 } " Model ->"
+                                    , Fix.removeRange { start = { row = 5, column = 8 }, end = { row = 5, column = 14 } }
+                                    , Fix.insertAt { row = 5, column = 18 } "model "
+                                    ]
                               ]
                             , context
                             )

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -6,7 +6,7 @@ module DataArgumentShouldBeLast exposing (rule)
 
 -}
 
-import Elm.Syntax.Declaration exposing (Declaration)
+import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Node as Node exposing (Node)
 import Review.Rule as Rule exposing (Rule)
 
@@ -102,5 +102,13 @@ foldProjectContexts new previous =
 declarationVisitor : Node Declaration -> ProjectContext -> ( List (Rule.Error {}), ProjectContext )
 declarationVisitor node context =
     case Node.value node of
+        Declaration.FunctionDeclaration { signature, declaration } ->
+            case signature of
+                Just type_ ->
+                    ( [], context )
+
+                Nothing ->
+                    ( [], context )
+
         _ ->
             ( [], context )

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -186,8 +186,8 @@ declarationVisitor node context =
 
 createFix : ModuleContext -> Int -> Range -> Int -> Range -> Node d -> List (Node Pattern) -> List Fix
 createFix context nbOfArguments argPosition argIndex nextArgumentRange returnType arguments =
-    case listAtIndex argIndex arguments of
-        Just { rangeToMove } ->
+    case Maybe.map2 Tuple.pair (listAtIndex argIndex arguments) (getLastArgAt nbOfArguments arguments) of
+        Just ( { rangeToMove }, lastArgPosition ) ->
             List.concat
                 [ moveCode context
                     { from = { start = argPosition.start, end = nextArgumentRange.start }
@@ -328,3 +328,13 @@ listAtIndex index list =
 
             else
                 listAtIndex (index - 1) xs
+
+
+getLastArgAt : Int -> List (Node a) -> Maybe Range
+getLastArgAt nbOfArguments arguments =
+    case List.drop (nbOfArguments - 1) arguments of
+        x :: [] ->
+            Just (Node.range x)
+
+        _ ->
+            Nothing

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -101,7 +101,7 @@ foldProjectContexts new previous =
     {}
 
 
-declarationVisitor : Node Declaration -> ProjectContext -> ( List (Rule.Error {}), ProjectContext )
+declarationVisitor : Node Declaration -> ModuleContext -> ( List (Rule.Error {}), ModuleContext )
 declarationVisitor node context =
     case Node.value node of
         Declaration.FunctionDeclaration { signature, declaration } ->

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -130,18 +130,19 @@ declarationVisitor node context =
 isNotDataLast : Node TypeAnnotation -> Maybe b
 isNotDataLast type_ =
     let
-        { returnType } =
+        { returnType, arguments } =
             getReturnType type_ []
     in
     Nothing
 
 
-getReturnType : Node TypeAnnotation -> List (Node TypeAnnotation) -> { returnType : TypeAnnotation }
+getReturnType : Node TypeAnnotation -> List TypeAnnotation -> { returnType : TypeAnnotation, arguments : List TypeAnnotation }
 getReturnType type_ argsAcc =
     case Node.value type_ of
         TypeAnnotation.FunctionTypeAnnotation arg return_ ->
-            getReturnType return_ (arg :: argsAcc)
+            getReturnType return_ (Node.value arg :: argsAcc)
 
         _ ->
             { returnType = Node.value type_
+            , arguments = argsAcc
             }

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -12,7 +12,6 @@ import Elm.Syntax.Range as Range exposing (Range)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (RecordField, TypeAnnotation)
 import Review.ModuleNameLookupTable as ModuleNameLookupTable exposing (ModuleNameLookupTable)
 import Review.Rule as Rule exposing (Rule)
-import Set exposing (Set)
 
 
 {-| Reports... REPLACEME
@@ -69,7 +68,6 @@ type alias ProjectContext =
 
 type alias ModuleContext =
     { lookupTable : ModuleNameLookupTable
-    , localTypes : Set String
     }
 
 
@@ -87,13 +85,11 @@ initialProjectContext =
 fromProjectToModule : Rule.ContextCreator ProjectContext ModuleContext
 fromProjectToModule =
     Rule.initContextCreator
-        (\lookupTable ast projectContext ->
+        (\lookupTable projectContext ->
             { lookupTable = lookupTable
-            , localTypes = getTypeNames ast.declarations Set.empty
             }
         )
         |> Rule.withModuleNameLookupTable
-        |> Rule.withFullAst
 
 
 fromModuleToProject : Rule.ContextCreator ModuleContext ProjectContext
@@ -107,34 +103,6 @@ fromModuleToProject =
 foldProjectContexts : ProjectContext -> ProjectContext -> ProjectContext
 foldProjectContexts new previous =
     {}
-
-
-getTypeNames : List (Node Declaration) -> Set String -> Set String
-getTypeNames nodes acc =
-    case nodes of
-        [] ->
-            acc
-
-        node :: rest ->
-            case getTypeName node of
-                Just name ->
-                    getTypeNames rest (Set.insert name acc)
-
-                Nothing ->
-                    getTypeNames rest acc
-
-
-getTypeName : Node Declaration -> Maybe String
-getTypeName node =
-    case Node.value node of
-        Declaration.CustomTypeDeclaration { name } ->
-            Just (Node.value name)
-
-        Declaration.AliasDeclaration { name } ->
-            Just (Node.value name)
-
-        _ ->
-            Nothing
 
 
 declarationVisitor : Node Declaration -> ModuleContext -> ( List (Rule.Error {}), ModuleContext )

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -158,7 +158,7 @@ declarationVisitor node context =
                 Just (Node _ type_) ->
                     case isNotDataLast type_.typeAnnotation context.lookupTable of
                         Just { argPosition, returnType } ->
-                            ( [ Rule.error
+                            ( [ Rule.errorWithFix
                                     { message = "The data argument should be last"
                                     , details =
                                         [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
@@ -166,6 +166,7 @@ declarationVisitor node context =
                                         ]
                                     }
                                     argPosition
+                                    []
                               ]
                             , context
                             )

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -127,6 +127,7 @@ type alias ModuleContext =
 type alias PendingError =
     { range : Range
     , nbOfArguments : Int
+    , indexOfMovedArgument : Int
     , fixes : List Fix
     }
 
@@ -207,6 +208,7 @@ declarationVisitor node context =
                                         (Node.value (Node.value declaration).name)
                                         { range = argPosition
                                         , nbOfArguments = nbOfArguments
+                                        , indexOfMovedArgument = argIndex
                                         , fixes =
                                             if context.isExposed (Node.value (Node.value declaration).name) then
                                                 []

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -8,7 +8,7 @@ module DataArgumentShouldBeLast exposing (rule)
 
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Node as Node exposing (Node(..))
-import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation)
+import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (TypeAnnotation)
 import Review.Rule as Rule exposing (Rule)
 
 
@@ -129,4 +129,19 @@ declarationVisitor node context =
 
 isNotDataLast : Node TypeAnnotation -> Maybe b
 isNotDataLast type_ =
+    let
+        returnType : Node TypeAnnotation
+        returnType =
+            getReturnType type_ []
+    in
     Nothing
+
+
+getReturnType : Node TypeAnnotation -> List (Node TypeAnnotation) -> Node TypeAnnotation
+getReturnType type_ argsAcc =
+    case Node.value type_ of
+        TypeAnnotation.FunctionTypeAnnotation arg return_ ->
+            getReturnType type_ (arg :: argsAcc)
+
+        _ ->
+            type_

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -144,7 +144,7 @@ declarationVisitor node context =
         Declaration.FunctionDeclaration { signature, declaration } ->
             case signature of
                 Just (Node _ type_) ->
-                    case isNotDataLast type_.typeAnnotation of
+                    case isNotDataLast type_.typeAnnotation context.localTypes of
                         Just { argPosition, returnType } ->
                             ( [ Rule.error
                                     { message = "REPLACEME"
@@ -165,8 +165,8 @@ declarationVisitor node context =
             ( [], context )
 
 
-isNotDataLast : Node TypeAnnotation -> Maybe { argPosition : Range, returnType : TypeAnnotation }
-isNotDataLast type_ =
+isNotDataLast : Node TypeAnnotation -> Set String -> Maybe { argPosition : Range, returnType : TypeAnnotation }
+isNotDataLast type_ localTypes =
     let
         { returnType, arguments } =
             getReturnType type_ []

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -168,7 +168,7 @@ declarationVisitor node context =
                                         ]
                                     }
                                     argPosition
-                                    [ Fix.removeRange { start = { row = 4, column = 10 }, end = { row = 4, column = 19 } }
+                                    [ Fix.removeRange { start = argPosition.start, end = nextArgumentRange.start }
                                     , Fix.insertAt { row = 4, column = 25 } " Model ->"
                                     , Fix.removeRange { start = { row = 5, column = 8 }, end = { row = 5, column = 14 } }
                                     , Fix.insertAt { row = 5, column = 18 } "model "

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -105,11 +105,6 @@ foldProjectContexts new previous =
     {}
 
 
-declarationListVisitor : List (Node Declaration) -> ModuleContext -> ( List (Rule.Error {}), ModuleContext )
-declarationListVisitor nodes context =
-    ( [], { localTypes = Set.empty } )
-
-
 getTypeNames : List (Node Declaration) -> Set String -> Set String
 getTypeNames nodes acc =
     case nodes of

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -10,6 +10,7 @@ import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Range as Range exposing (Range)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (RecordField, TypeAnnotation)
+import Review.ModuleNameLookupTable exposing (ModuleNameLookupTable)
 import Review.Rule as Rule exposing (Rule)
 import Set exposing (Set)
 
@@ -67,7 +68,8 @@ type alias ProjectContext =
 
 
 type alias ModuleContext =
-    { localTypes : Set String
+    { lookupTable : ModuleNameLookupTable
+    , localTypes : Set String
     }
 
 
@@ -85,10 +87,12 @@ initialProjectContext =
 fromProjectToModule : Rule.ContextCreator ProjectContext ModuleContext
 fromProjectToModule =
     Rule.initContextCreator
-        (\ast projectContext ->
-            { localTypes = getTypeNames ast.declarations Set.empty
+        (\lookupTable ast projectContext ->
+            { lookupTable = lookupTable
+            , localTypes = getTypeNames ast.declarations Set.empty
             }
         )
+        |> Rule.withModuleNameLookupTable
         |> Rule.withFullAst
 
 

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -7,7 +7,8 @@ module DataArgumentShouldBeLast exposing (rule)
 -}
 
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
-import Elm.Syntax.Node as Node exposing (Node)
+import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation)
 import Review.Rule as Rule exposing (Rule)
 
 
@@ -104,18 +105,28 @@ declarationVisitor node context =
     case Node.value node of
         Declaration.FunctionDeclaration { signature, declaration } ->
             case signature of
-                Just type_ ->
-                    ( [ Rule.error
-                            { message = "REPLACEME"
-                            , details = [ "REPLACEME" ]
-                            }
-                            (Node.range node)
-                      ]
-                    , context
-                    )
+                Just (Node _ type_) ->
+                    case isNotDataLast type_.typeAnnotation of
+                        Just { dataPosition, returnType } ->
+                            ( [ Rule.error
+                                    { message = "REPLACEME"
+                                    , details = [ "REPLACEME" ]
+                                    }
+                                    (Node.range node)
+                              ]
+                            , context
+                            )
+
+                        Nothing ->
+                            ( [], context )
 
                 Nothing ->
                     ( [], context )
 
         _ ->
             ( [], context )
+
+
+isNotDataLast : Node TypeAnnotation -> Maybe b
+isNotDataLast type_ =
+    Nothing

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -249,7 +249,7 @@ expressionVisitor node context =
                                 ( []
                                 , { context
                                     | rangeToIgnore = Just fnRange
-                                    , errors = Dict.insert name error context.errors
+                                    , errors = Dict.insert name { error | fixes = error.fixes } context.errors
                                   }
                                 )
 

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -108,12 +108,12 @@ declarationVisitor node context =
             case signature of
                 Just (Node _ type_) ->
                     case isNotDataLast type_.typeAnnotation of
-                        Just { dataPosition, returnType } ->
+                        Just { argPosition, returnType } ->
                             ( [ Rule.error
                                     { message = "REPLACEME"
                                     , details = [ "REPLACEME" ]
                                     }
-                                    (Node.range node)
+                                    argPosition
                               ]
                             , context
                             )
@@ -128,7 +128,7 @@ declarationVisitor node context =
             ( [], context )
 
 
-isNotDataLast : Node TypeAnnotation -> Maybe { dataPosition : Range, returnType : TypeAnnotation }
+isNotDataLast : Node TypeAnnotation -> Maybe { argPosition : Range, returnType : TypeAnnotation }
 isNotDataLast type_ =
     let
         { returnType, arguments } =
@@ -143,7 +143,7 @@ isNotDataLast type_ =
                 case find (\arg -> Node.value arg == returnType) rest of
                     Just arg ->
                         Just
-                            { dataPosition = Node.range arg
+                            { argPosition = Node.range arg
                             , returnType = returnType
                             }
 
@@ -160,7 +160,7 @@ getReturnType : Node TypeAnnotation -> List (Node TypeAnnotation) -> { returnTyp
 getReturnType type_ argsAcc =
     case Node.value type_ of
         TypeAnnotation.FunctionTypeAnnotation arg return_ ->
-            getReturnType return_ (removeRange arg :: argsAcc)
+            getReturnType return_ ((Node (Node.range arg) <| Node.value <| removeRange arg) :: argsAcc)
 
         _ ->
             { returnType = Node.value (removeRange type_)

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -8,7 +8,7 @@ module DataArgumentShouldBeLast exposing (rule)
 
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Node as Node exposing (Node(..))
-import Elm.Syntax.Range as Range
+import Elm.Syntax.Range as Range exposing (Range)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (RecordField, TypeAnnotation)
 import Review.Rule as Rule exposing (Rule)
 
@@ -128,13 +128,21 @@ declarationVisitor node context =
             ( [], context )
 
 
-isNotDataLast : Node TypeAnnotation -> Maybe b
+isNotDataLast : Node TypeAnnotation -> Maybe { dataPosition : Range, returnType : TypeAnnotation }
 isNotDataLast type_ =
     let
         { returnType, arguments } =
             getReturnType type_ []
     in
-    Nothing
+    case arguments of
+        firstArg :: rest ->
+            Just
+                { dataPosition = Node.range firstArg
+                , returnType = returnType
+                }
+
+        [] ->
+            Nothing
 
 
 {-| Returned arguments are in the opposite order.

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -186,16 +186,21 @@ declarationVisitor node context =
 
 createFix : ModuleContext -> Range -> Int -> Range -> Node d -> List (Node Pattern) -> List Fix
 createFix context argPosition argIndex nextArgumentRange returnType arguments =
-    let
-        argTypeRange : Range
-        argTypeRange =
-            { start = argPosition.start, end = nextArgumentRange.start }
-    in
-    [ Fix.removeRange argTypeRange
-    , Fix.insertAt (Node.range returnType).start (context.extractSourceCode argTypeRange)
-    , Fix.removeRange { start = { row = 5, column = 8 }, end = { row = 5, column = 14 } }
-    , Fix.insertAt { row = 5, column = 18 } "model "
-    ]
+    case listAtIndex argIndex arguments of
+        Just arg ->
+            let
+                argTypeRange : Range
+                argTypeRange =
+                    { start = argPosition.start, end = nextArgumentRange.start }
+            in
+            [ Fix.removeRange argTypeRange
+            , Fix.insertAt (Node.range returnType).start (context.extractSourceCode argTypeRange)
+            , Fix.removeRange { start = { row = 5, column = 8 }, end = { row = 5, column = 14 } }
+            , Fix.insertAt { row = 5, column = 18 } "model "
+            ]
+
+        Nothing ->
+            []
 
 
 isNotDataLast : Node TypeAnnotation -> ModuleNameLookupTable -> Maybe { argPosition : Range, argIndex : Int, nextArgumentRange : Range, returnType : Node TypeAnnotation }
@@ -292,3 +297,17 @@ findAndGiveElementAndItsPrevious predicate index previous list =
 
             else
                 findAndGiveElementAndItsPrevious predicate (index + 1) x xs
+
+
+listAtIndex : Int -> List a -> Maybe a
+listAtIndex index list =
+    case list of
+        [] ->
+            Nothing
+
+        x :: xs ->
+            if index == 0 then
+                Just x
+
+            else
+                listAtIndex (index - 1) xs

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -131,7 +131,7 @@ type alias PendingError =
 moduleVisitor : Rule.ModuleRuleSchema schema ModuleContext -> Rule.ModuleRuleSchema { schema | hasAtLeastOneVisitor : () } ModuleContext
 moduleVisitor schema =
     schema
-        |> Rule.withDeclarationEnterVisitor declarationVisitor
+        |> Rule.withDeclarationListVisitor declarationListVisitor
         |> Rule.withExpressionEnterVisitor expressionVisitor
         |> Rule.withFinalModuleEvaluation finalEvaluation
 
@@ -172,6 +172,20 @@ fromModuleToProject =
 foldProjectContexts : ProjectContext -> ProjectContext -> ProjectContext
 foldProjectContexts new previous =
     {}
+
+
+declarationListVisitor : List (Node Declaration) -> ModuleContext -> ( List (Rule.Error {}), ModuleContext )
+declarationListVisitor nodes context =
+    List.foldl
+        (\node ( previousErrors, previousContext ) ->
+            let
+                ( newErrors, newContext ) =
+                    declarationVisitor node previousContext
+            in
+            ( newErrors ++ previousErrors, newContext )
+        )
+        ( [], context )
+        nodes
 
 
 declarationVisitor : Node Declaration -> ModuleContext -> ( List (Rule.Error {}), ModuleContext )

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -350,7 +350,7 @@ isNotDataLast type_ lookupTable =
         Just { returnType, arguments } ->
             case arguments of
                 firstArg :: rest ->
-                    if Node.value firstArg == Node.value returnType then
+                    if isTypeEqual firstArg returnType then
                         Nothing
 
                     else
@@ -369,6 +369,11 @@ isNotDataLast type_ lookupTable =
 
                 [] ->
                     Nothing
+
+
+isTypeEqual : Node TypeAnnotation -> Node TypeAnnotation -> Bool
+isTypeEqual (Node _ a) (Node _ b) =
+    a == b
 
 
 {-| Returned arguments are in the opposite order.

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -185,15 +185,19 @@ declarationVisitor node context =
                                 | errors =
                                     { range = argPosition
                                     , fixes =
-                                        createFix
-                                            context
-                                            nbOfArguments
-                                            argPosition
-                                            argIndex
-                                            nextArgumentRange
-                                            returnType
-                                            (Node.range (Node.value declaration).name).end
-                                            (Node.value declaration).arguments
+                                        if context.isExposed (Node.value (Node.value declaration).name) then
+                                            []
+
+                                        else
+                                            createFix
+                                                context
+                                                nbOfArguments
+                                                argPosition
+                                                argIndex
+                                                nextArgumentRange
+                                                returnType
+                                                (Node.range (Node.value declaration).name).end
+                                                (Node.value declaration).arguments
                                     }
                                         :: context.errors
                               }

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -8,6 +8,7 @@ module DataArgumentShouldBeLast exposing (rule)
 
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.Pattern exposing (Pattern)
 import Elm.Syntax.Range as Range exposing (Range)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (RecordField, TypeAnnotation)
 import Review.Fix as Fix exposing (Fix)
@@ -168,7 +169,7 @@ declarationVisitor node context =
                                         ]
                                     }
                                     argPosition
-                                    (createFix context argPosition argIndex nextArgumentRange returnType)
+                                    (createFix context argPosition argIndex nextArgumentRange returnType (Node.value declaration).arguments)
                               ]
                             , context
                             )
@@ -183,8 +184,8 @@ declarationVisitor node context =
             ( [], context )
 
 
-createFix : ModuleContext -> Range -> Int -> Range -> Node d -> List Fix
-createFix context argPosition argIndex nextArgumentRange returnType =
+createFix : ModuleContext -> Range -> Int -> Range -> Node d -> List (Node Pattern) -> List Fix
+createFix context argPosition argIndex nextArgumentRange returnType arguments =
     let
         argTypeRange : Range
         argTypeRange =

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -139,11 +139,11 @@ isNotDataLast type_ =
 
 {-| Returned arguments are in the opposite order.
 -}
-getReturnType : Node TypeAnnotation -> List TypeAnnotation -> { returnType : TypeAnnotation, arguments : List TypeAnnotation }
+getReturnType : Node TypeAnnotation -> List (Node TypeAnnotation) -> { returnType : TypeAnnotation, arguments : List (Node TypeAnnotation) }
 getReturnType type_ argsAcc =
     case Node.value type_ of
         TypeAnnotation.FunctionTypeAnnotation arg return_ ->
-            getReturnType return_ (Node.value (removeRange arg) :: argsAcc)
+            getReturnType return_ (removeRange arg :: argsAcc)
 
         _ ->
             { returnType = Node.value (removeRange type_)

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -236,11 +236,16 @@ expressionVisitor : Node Expression -> ModuleContext -> ( List (Rule.Error {}), 
 expressionVisitor node context =
     case Node.value node of
         Expression.FunctionOrValue [] name ->
-            case ModuleNameLookupTable.moduleNameFor context.lookupTable node of
-                Just [] ->
-                    ( [], context )
+            case Dict.get name context.errors of
+                Just error ->
+                    case ModuleNameLookupTable.moduleNameFor context.lookupTable node of
+                        Just [] ->
+                            ( [], context )
 
-                _ ->
+                        _ ->
+                            ( [], context )
+
+                Nothing ->
                     ( [], context )
 
         _ ->

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -236,7 +236,12 @@ expressionVisitor : Node Expression -> ModuleContext -> ( List (Rule.Error {}), 
 expressionVisitor node context =
     case Node.value node of
         Expression.FunctionOrValue [] name ->
-            ( [], context )
+            case ModuleNameLookupTable.moduleNameFor context.lookupTable node of
+                Just [] ->
+                    ( [], context )
+
+                _ ->
+                    ( [], context )
 
         _ ->
             ( [], context )

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -167,42 +167,44 @@ declarationVisitor node context =
 
 isNotDataLast : Node TypeAnnotation -> Set String -> Maybe { argPosition : Range, returnType : TypeAnnotation }
 isNotDataLast type_ localTypes =
-    let
-        { returnType, arguments } =
-            getArguments type_ []
-    in
-    case arguments of
-        firstArg :: rest ->
-            if Node.value firstArg == returnType then
-                Nothing
+    case getArguments type_ [] of
+        Nothing ->
+            Nothing
 
-            else
-                case find (\arg -> Node.value arg == returnType) rest of
-                    Just arg ->
-                        Just
-                            { argPosition = Node.range arg
-                            , returnType = returnType
-                            }
-
-                    Nothing ->
+        Just { returnType, arguments } ->
+            case arguments of
+                firstArg :: rest ->
+                    if Node.value firstArg == returnType then
                         Nothing
 
-        [] ->
-            Nothing
+                    else
+                        case find (\arg -> Node.value arg == returnType) rest of
+                            Just arg ->
+                                Just
+                                    { argPosition = Node.range arg
+                                    , returnType = returnType
+                                    }
+
+                            Nothing ->
+                                Nothing
+
+                [] ->
+                    Nothing
 
 
 {-| Returned arguments are in the opposite order.
 -}
-getArguments : Node TypeAnnotation -> List (Node TypeAnnotation) -> { returnType : TypeAnnotation, arguments : List (Node TypeAnnotation) }
+getArguments : Node TypeAnnotation -> List (Node TypeAnnotation) -> Maybe { returnType : TypeAnnotation, arguments : List (Node TypeAnnotation) }
 getArguments type_ argsAcc =
     case Node.value type_ of
         TypeAnnotation.FunctionTypeAnnotation arg return_ ->
             getArguments return_ ((Node (Node.range arg) <| Node.value <| removeRange arg) :: argsAcc)
 
         _ ->
-            { returnType = Node.value (removeRange type_)
-            , arguments = argsAcc
-            }
+            Just
+                { returnType = Node.value (removeRange type_)
+                , arguments = argsAcc
+                }
 
 
 removeRange : Node TypeAnnotation -> Node TypeAnnotation

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -255,20 +255,24 @@ expressionVisitor node context =
 finalEvaluation : ModuleContext -> List (Rule.Error {})
 finalEvaluation moduleContext =
     Dict.foldl
-        (\_ { range, fixes } errors ->
-            Rule.errorWithFix
-                { message = "The data argument should be last"
-                , details =
-                    [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
-                    , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
-                    ]
-                }
-                range
-                fixes
-                :: errors
+        (\_ error errors ->
+            createError error :: errors
         )
         []
         moduleContext.errors
+
+
+createError : PendingError -> Rule.Error {}
+createError { range, fixes } =
+    Rule.errorWithFix
+        { message = "The data argument should be last"
+        , details =
+            [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
+            , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
+            ]
+        }
+        range
+        fixes
 
 
 createFix : ModuleContext -> Int -> Range -> Int -> Range -> Node d -> Location -> List (Node Pattern) -> List Fix

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -200,8 +200,8 @@ isNotDataLast type_ lookupTable =
                         Nothing
 
                     else
-                        case find (\arg -> Node.value arg == Node.value returnType) rest of
-                            Just arg ->
+                        case findAndGiveElementAndItsPrevious (\arg -> Node.value arg == Node.value returnType) firstArg rest of
+                            Just ( arg, nextElement ) ->
                                 Just
                                     { argPosition = Node.range arg
                                     , returnType = returnType
@@ -267,15 +267,15 @@ removeRangeFromRecordField (Node _ ( Node _ property, value )) =
     Node Range.emptyRange ( Node Range.emptyRange property, removeRange value )
 
 
-find : (a -> Bool) -> List a -> Maybe a
-find predicate list =
+findAndGiveElementAndItsPrevious : (a -> Bool) -> a -> List a -> Maybe ( a, a )
+findAndGiveElementAndItsPrevious predicate previous list =
     case list of
         [] ->
             Nothing
 
         x :: xs ->
             if predicate x then
-                Just x
+                Just ( x, previous )
 
             else
-                find predicate xs
+                findAndGiveElementAndItsPrevious predicate x xs

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -11,6 +11,7 @@ import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Range as Range exposing (Range)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (RecordField, TypeAnnotation)
 import Review.Rule as Rule exposing (Rule)
+import Set exposing (Set)
 
 
 {-| Reports... REPLACEME
@@ -66,7 +67,8 @@ type alias ProjectContext =
 
 
 type alias ModuleContext =
-    {}
+    { localTypes : Set String
+    }
 
 
 moduleVisitor : Rule.ModuleRuleSchema schema ModuleContext -> Rule.ModuleRuleSchema { schema | hasAtLeastOneVisitor : () } ModuleContext
@@ -84,7 +86,8 @@ fromProjectToModule : Rule.ContextCreator ProjectContext ModuleContext
 fromProjectToModule =
     Rule.initContextCreator
         (\projectContext ->
-            {}
+            { localTypes = Set.empty
+            }
         )
 
 

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -374,8 +374,28 @@ isNotDataLast type_ lookupTable =
 isTypeEqual : ModuleNameLookupTable -> Node TypeAnnotation -> Node TypeAnnotation -> Bool
 isTypeEqual lookupTable node returnType =
     case Node.value node of
-        TypeAnnotation.Typed _ _ ->
-            Node.value node == Node.value returnType
+        TypeAnnotation.Typed (Node _ ( _, nameA )) _ ->
+            case Node.value returnType of
+                TypeAnnotation.Typed (Node _ ( _, nameB )) _ ->
+                    if nameA /= nameB then
+                        False
+
+                    else
+                        case ModuleNameLookupTable.moduleNameFor lookupTable node of
+                            Just moduleNameA ->
+                                case ModuleNameLookupTable.moduleNameFor lookupTable returnType of
+                                    Just moduleNameB ->
+                                        -- It's okay if the type variables are different
+                                        moduleNameA == moduleNameB
+
+                                    Nothing ->
+                                        False
+
+                            _ ->
+                                False
+
+                _ ->
+                    False
 
         TypeAnnotation.Record fields ->
             case Node.value returnType of

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -164,26 +164,29 @@ declarationVisitor node context =
                 Just (Node _ type_) ->
                     case isNotDataLast type_.typeAnnotation context.lookupTable of
                         Just { argPosition, argIndex, nextArgumentRange, nbOfArguments, returnType } ->
-                            ( [ Rule.errorWithFix
-                                    { message = "The data argument should be last"
-                                    , details =
-                                        [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
-                                        , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
-                                        ]
-                                    }
-                                    argPosition
-                                    (createFix
-                                        context
-                                        nbOfArguments
+                            ( []
+                            , { context
+                                | errors =
+                                    Rule.errorWithFix
+                                        { message = "The data argument should be last"
+                                        , details =
+                                            [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
+                                            , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
+                                            ]
+                                        }
                                         argPosition
-                                        argIndex
-                                        nextArgumentRange
-                                        returnType
-                                        (Node.range (Node.value declaration).name).end
-                                        (Node.value declaration).arguments
-                                    )
-                              ]
-                            , context
+                                        (createFix
+                                            context
+                                            nbOfArguments
+                                            argPosition
+                                            argIndex
+                                            nextArgumentRange
+                                            returnType
+                                            (Node.range (Node.value declaration).name).end
+                                            (Node.value declaration).arguments
+                                        )
+                                        :: context.errors
+                              }
                             )
 
                         Nothing ->

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -232,7 +232,7 @@ getArguments type_ lookupTable argsAcc =
             case ModuleNameLookupTable.moduleNameFor lookupTable type_ of
                 Just [] ->
                     Just
-                        { returnType = removeRange type_
+                        { returnType = Node (Node.range type_) <| Node.value <| removeRange type_
                         , arguments = argsAcc
                         }
 

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -210,11 +210,11 @@ isNotDataLast type_ lookupTable =
                         Nothing
 
                     else
-                        case findAndGiveElementAndItsPrevious (\arg -> Node.value arg == Node.value returnType) firstArg rest of
-                            Just ( arg, nextElement ) ->
+                        case findAndGiveElementAndItsPrevious (\arg -> Node.value arg == Node.value returnType) 0 firstArg rest of
+                            Just ( arg, argIndex, nextElement ) ->
                                 Just
                                     { argPosition = Node.range arg
-                                    , argIndex = 0
+                                    , argIndex = argIndex
                                     , nextArgumentRange = Node.range nextElement
                                     , returnType = returnType
                                     }
@@ -279,15 +279,15 @@ removeRangeFromRecordField (Node _ ( Node _ property, value )) =
     Node Range.emptyRange ( Node Range.emptyRange property, removeRange value )
 
 
-findAndGiveElementAndItsPrevious : (a -> Bool) -> a -> List a -> Maybe ( a, a )
-findAndGiveElementAndItsPrevious predicate previous list =
+findAndGiveElementAndItsPrevious : (a -> Bool) -> Int -> a -> List a -> Maybe ( a, Int, a )
+findAndGiveElementAndItsPrevious predicate index previous list =
     case list of
         [] ->
             Nothing
 
         x :: xs ->
             if predicate x then
-                Just ( x, previous )
+                Just ( x, index, previous )
 
             else
-                findAndGiveElementAndItsPrevious predicate x xs
+                findAndGiveElementAndItsPrevious predicate (index + 1) x xs

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -130,18 +130,18 @@ declarationVisitor node context =
 isNotDataLast : Node TypeAnnotation -> Maybe b
 isNotDataLast type_ =
     let
-        returnType : TypeAnnotation
-        returnType =
+        { returnType } =
             getReturnType type_ []
     in
     Nothing
 
 
-getReturnType : Node TypeAnnotation -> List (Node TypeAnnotation) -> TypeAnnotation
+getReturnType : Node TypeAnnotation -> List (Node TypeAnnotation) -> { returnType : TypeAnnotation }
 getReturnType type_ argsAcc =
     case Node.value type_ of
         TypeAnnotation.FunctionTypeAnnotation arg return_ ->
             getReturnType return_ (arg :: argsAcc)
 
         _ ->
-            Node.value type_
+            { returnType = Node.value type_
+            }

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -121,6 +121,7 @@ moduleVisitor : Rule.ModuleRuleSchema schema ModuleContext -> Rule.ModuleRuleSch
 moduleVisitor schema =
     schema
         |> Rule.withDeclarationEnterVisitor declarationVisitor
+        |> Rule.withFinalModuleEvaluation finalEvaluation
 
 
 initialProjectContext : ProjectContext
@@ -191,6 +192,11 @@ declarationVisitor node context =
 
         _ ->
             ( [], context )
+
+
+finalEvaluation : ModuleContext -> List (Rule.Error {})
+finalEvaluation moduleContext =
+    []
 
 
 createFix : ModuleContext -> Int -> Range -> Int -> Range -> Node d -> Location -> List (Node Pattern) -> List Fix

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -456,7 +456,7 @@ areFieldsEqual lookupTable fieldsA fieldsB =
         List.map2
             (\(Node _ ( nameA, a )) (Node _ ( nameB, b )) ->
                 \() ->
-                    if nameA == nameB then
+                    if Node.value nameA == Node.value nameB then
                         isTypeEqual lookupTable a b
 
                     else

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -126,6 +126,7 @@ type alias ModuleContext =
 
 type alias PendingError =
     { range : Range
+    , nbOfArguments : Int
     , fixes : List Fix
     }
 
@@ -205,6 +206,7 @@ declarationVisitor node context =
                                     Dict.insert
                                         (Node.value (Node.value declaration).name)
                                         { range = argPosition
+                                        , nbOfArguments = nbOfArguments
                                         , fixes =
                                             if context.isExposed (Node.value (Node.value declaration).name) then
                                                 []

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -200,11 +200,14 @@ getArguments type_ localTypes argsAcc =
         TypeAnnotation.FunctionTypeAnnotation arg return_ ->
             getArguments return_ localTypes ((Node (Node.range arg) <| Node.value <| removeRange arg) :: argsAcc)
 
-        _ ->
+        TypeAnnotation.Typed _ _ ->
             Just
                 { returnType = Node.value (removeRange type_)
                 , arguments = argsAcc
                 }
+
+        _ ->
+            Nothing
 
 
 removeRange : Node TypeAnnotation -> Node TypeAnnotation

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -187,7 +187,7 @@ declarationVisitor node context =
 createFix : ModuleContext -> Int -> Range -> Int -> Range -> Node d -> List (Node Pattern) -> List Fix
 createFix context nbOfArguments argPosition argIndex nextArgumentRange returnType arguments =
     case Maybe.map2 Tuple.pair (listAtIndex argIndex arguments) (getLastArgAt nbOfArguments arguments) of
-        Just ( { rangeToMove }, lastArgPosition ) ->
+        Just ( rangeToMove, lastArgPosition ) ->
             List.concat
                 [ moveCode context
                     { from = { start = argPosition.start, end = nextArgumentRange.start }
@@ -307,7 +307,7 @@ findAndGiveElementAndItsPrevious predicate index previous list =
                 findAndGiveElementAndItsPrevious predicate (index + 1) x xs
 
 
-listAtIndex : Int -> List (Node a) -> Maybe { rangeToMove : Range }
+listAtIndex : Int -> List (Node a) -> Maybe Range
 listAtIndex index list =
     case list of
         [] ->
@@ -317,9 +317,7 @@ listAtIndex index list =
             if index == 0 then
                 case List.head xs of
                     Just next ->
-                        Just
-                            { rangeToMove = { start = (Node.range x).start, end = (Node.range next).start }
-                            }
+                        Just { start = (Node.range x).start, end = (Node.range next).start }
 
                     Nothing ->
                         -- If there is no next element, then not all arguments are declared

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -120,6 +120,7 @@ type alias ModuleContext =
     , lookupTable : ModuleNameLookupTable
     , extractSourceCode : Range -> String
     , errors : Dict String PendingError
+    , rangeToIgnore : Maybe Range
     }
 
 
@@ -155,6 +156,7 @@ fromProjectToModule =
             , extractSourceCode = extractSourceCode
             , errors = Dict.empty
             , isExposed = \name -> Exposing.exposesFunction name exposing_
+            , rangeToIgnore = Nothing
             }
         )
         |> Rule.withModuleNameLookupTable

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -136,10 +136,14 @@ isNotDataLast type_ =
     in
     case arguments of
         firstArg :: rest ->
-            Just
-                { dataPosition = Node.range firstArg
-                , returnType = returnType
-                }
+            if Node.value firstArg == returnType then
+                Nothing
+
+            else
+                Just
+                    { dataPosition = Node.range firstArg
+                    , returnType = returnType
+                    }
 
         [] ->
             Nothing

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -167,7 +167,7 @@ declarationVisitor node context =
 
 isNotDataLast : Node TypeAnnotation -> Set String -> Maybe { argPosition : Range, returnType : TypeAnnotation }
 isNotDataLast type_ localTypes =
-    case getArguments type_ [] of
+    case getArguments type_ localTypes [] of
         Nothing ->
             Nothing
 
@@ -194,11 +194,11 @@ isNotDataLast type_ localTypes =
 
 {-| Returned arguments are in the opposite order.
 -}
-getArguments : Node TypeAnnotation -> List (Node TypeAnnotation) -> Maybe { returnType : TypeAnnotation, arguments : List (Node TypeAnnotation) }
-getArguments type_ argsAcc =
+getArguments : Node TypeAnnotation -> Set String -> List (Node TypeAnnotation) -> Maybe { returnType : TypeAnnotation, arguments : List (Node TypeAnnotation) }
+getArguments type_ localTypes argsAcc =
     case Node.value type_ of
         TypeAnnotation.FunctionTypeAnnotation arg return_ ->
-            getArguments return_ ((Node (Node.range arg) <| Node.value <| removeRange arg) :: argsAcc)
+            getArguments return_ localTypes ((Node (Node.range arg) <| Node.value <| removeRange arg) :: argsAcc)
 
         _ ->
             Just

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -114,6 +114,7 @@ type alias ProjectContext =
 type alias ModuleContext =
     { lookupTable : ModuleNameLookupTable
     , extractSourceCode : Range -> String
+    , errors : List (Rule.Error {})
     }
 
 
@@ -135,6 +136,7 @@ fromProjectToModule =
         (\lookupTable extractSourceCode projectContext ->
             { lookupTable = lookupTable
             , extractSourceCode = extractSourceCode
+            , errors = []
             }
         )
         |> Rule.withModuleNameLookupTable

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -8,6 +8,7 @@ module DataArgumentShouldBeLast exposing (rule)
 
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Exposing as Exposing exposing (Exposing)
+import Elm.Syntax.Expression as Expression exposing (Expression)
 import Elm.Syntax.Module as Module
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (Pattern)
@@ -131,6 +132,7 @@ moduleVisitor : Rule.ModuleRuleSchema schema ModuleContext -> Rule.ModuleRuleSch
 moduleVisitor schema =
     schema
         |> Rule.withDeclarationEnterVisitor declarationVisitor
+        |> Rule.withExpressionEnterVisitor expressionVisitor
         |> Rule.withFinalModuleEvaluation finalEvaluation
 
 
@@ -208,6 +210,16 @@ declarationVisitor node context =
 
                 Nothing ->
                     ( [], context )
+
+        _ ->
+            ( [], context )
+
+
+expressionVisitor : Node Expression -> ModuleContext -> ( List (Rule.Error {}), ModuleContext )
+expressionVisitor node context =
+    case Node.value node of
+        Expression.FunctionOrValue [] name ->
+            ( [], context )
 
         _ ->
             ( [], context )

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -187,7 +187,7 @@ declarationVisitor node context =
             ( [], context )
 
 
-isNotDataLast : Node TypeAnnotation -> ModuleNameLookupTable -> Maybe { argPosition : Range, returnType : TypeAnnotation }
+isNotDataLast : Node TypeAnnotation -> ModuleNameLookupTable -> Maybe { argPosition : Range, returnType : Node TypeAnnotation }
 isNotDataLast type_ lookupTable =
     case getArguments type_ lookupTable [] of
         Nothing ->
@@ -196,11 +196,11 @@ isNotDataLast type_ lookupTable =
         Just { returnType, arguments } ->
             case arguments of
                 firstArg :: rest ->
-                    if Node.value firstArg == returnType then
+                    if Node.value firstArg == Node.value returnType then
                         Nothing
 
                     else
-                        case find (\arg -> Node.value arg == returnType) rest of
+                        case find (\arg -> Node.value arg == Node.value returnType) rest of
                             Just arg ->
                                 Just
                                     { argPosition = Node.range arg
@@ -216,7 +216,7 @@ isNotDataLast type_ lookupTable =
 
 {-| Returned arguments are in the opposite order.
 -}
-getArguments : Node TypeAnnotation -> ModuleNameLookupTable -> List (Node TypeAnnotation) -> Maybe { returnType : TypeAnnotation, arguments : List (Node TypeAnnotation) }
+getArguments : Node TypeAnnotation -> ModuleNameLookupTable -> List (Node TypeAnnotation) -> Maybe { returnType : Node TypeAnnotation, arguments : List (Node TypeAnnotation) }
 getArguments type_ lookupTable argsAcc =
     case Node.value type_ of
         TypeAnnotation.FunctionTypeAnnotation arg return_ ->
@@ -226,7 +226,7 @@ getArguments type_ lookupTable argsAcc =
             case ModuleNameLookupTable.moduleNameFor lookupTable type_ of
                 Just [] ->
                     Just
-                        { returnType = Node.value (removeRange type_)
+                        { returnType = removeRange type_
                         , arguments = argsAcc
                         }
 

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -140,10 +140,15 @@ isNotDataLast type_ =
                 Nothing
 
             else
-                Just
-                    { dataPosition = Node.range firstArg
-                    , returnType = returnType
-                    }
+                case find (\arg -> Node.value arg == returnType) rest of
+                    Just arg ->
+                        Just
+                            { dataPosition = Node.range arg
+                            , returnType = returnType
+                            }
+
+                    Nothing ->
+                        Nothing
 
         [] ->
             Nothing

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -306,7 +306,7 @@ findAndGiveElementAndItsPrevious predicate index previous list =
                 findAndGiveElementAndItsPrevious predicate (index + 1) x xs
 
 
-listAtIndex : Int -> List a -> Maybe a
+listAtIndex : Int -> List (Node a) -> Maybe Range
 listAtIndex index list =
     case list of
         [] ->
@@ -314,7 +314,14 @@ listAtIndex index list =
 
         x :: xs ->
             if index == 0 then
-                Just x
+                case List.head xs of
+                    Just next ->
+                        Just { start = (Node.range x).start, end = (Node.range next).start }
+
+                    Nothing ->
+                        -- If there is no next element, then not all arguments are declared
+                        -- and we should avoid providing a fix.
+                        Nothing
 
             else
                 listAtIndex (index - 1) xs

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -253,7 +253,7 @@ expressionVisitor node context =
                             in
                             if List.length arguments == error.nbOfArguments then
                                 -- TODO Add fixes
-                                case [] of
+                                case createFixesForFunctionCall arguments of
                                     [] ->
                                         cancelFixesAndReportError ()
 
@@ -295,6 +295,13 @@ expressionVisitor node context =
 
         _ ->
             ( [], context )
+
+
+createFixesForFunctionCall arguments =
+    -- TODO Create a fix for the function call.
+    -- We probably need to get more information like the position of the argument to move
+    -- That needs to come from the PendingError, but we don't store it there yet.
+    []
 
 
 finalEvaluation : ModuleContext -> List (Rule.Error {})

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -246,7 +246,12 @@ expressionVisitor node context =
                         Just [] ->
                             if List.length arguments == error.nbOfArguments then
                                 -- TODO Add fixes
-                                ( [], { context | rangeToIgnore = Just fnRange } )
+                                ( []
+                                , { context
+                                    | rangeToIgnore = Just fnRange
+                                    , errors = Dict.insert name error context.errors
+                                  }
+                                )
 
                             else
                                 ( [ createError { range = error.range, fixes = [] } ]

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -14,29 +14,71 @@ import Review.ModuleNameLookupTable as ModuleNameLookupTable exposing (ModuleNam
 import Review.Rule as Rule exposing (Rule)
 
 
-{-| Reports... REPLACEME
+{-| Reports functions where the data argument is not the last argument.
 
     config =
         [ DataArgumentShouldBeLast.rule
         ]
 
+This rule will report functions that return the same type as one of the arguments when that argument is not the last.
+
+The idea is to help make idiomatic Elm code, that makes it easy to compose code. For example, given the following functions:
+
+    newBicycle : Bicycle
+
+    withNumberOfGears : Int -> Bicycle -> Bicycle
+
+    withTire : Tire -> Bicycle -> Bicycle
+
+    withDutchBicycleLock : Bicycle -> Bicycle
+
+because the data that is being altered/modified is the last one, we can easily compose these functions using `|>`:
+
+    myBicycle : Bicycle
+    myBicycle =
+        newBicycle
+            |> withNumberOfGears 7
+            |> withTire mountainBikeTire
+            |> withDutchBicycleLock
+
+or using `>>` :
+
+    turnIntoMountainBike =
+        withNumberOfGears 7
+            >> withTire mountainBikeTire
+            >> withDutchBicycleLock
+
+If instead, we had `withNumberOfGears : Bicycle -> Int -> Bicycle`, this would not compose as well.
+
+In Elm code, because of this property, we often write our functions data-last in case we need to compose them with other ones.
+
 
 ## Fail
 
-    a =
-        "REPLACEME example to replace"
+    update : Model -> Msg -> Model
+    update model msg =
+        -- ...
 
 
 ## Success
 
-    a =
-        "REPLACEME example to replace"
+    update : Msg -> Model -> Model
+    update msg model =
+        -- ...
+
+
+## Boundaries of the rule
+
+To avoid false positives, this rule only applies in some conditions.
+
+REPLACEME
 
 
 ## When (not) to enable this rule
 
-This rule is useful when REPLACEME.
-This rule is not useful when REPLACEME.
+This rule can help make your Elm code more idiomatic.
+
+If you feel like this rule reports false positives, please open an issue.
 
 
 ## Try it out

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -130,18 +130,18 @@ declarationVisitor node context =
 isNotDataLast : Node TypeAnnotation -> Maybe b
 isNotDataLast type_ =
     let
-        returnType : Node TypeAnnotation
+        returnType : TypeAnnotation
         returnType =
             getReturnType type_ []
     in
     Nothing
 
 
-getReturnType : Node TypeAnnotation -> List (Node TypeAnnotation) -> Node TypeAnnotation
+getReturnType : Node TypeAnnotation -> List (Node TypeAnnotation) -> TypeAnnotation
 getReturnType type_ argsAcc =
     case Node.value type_ of
         TypeAnnotation.FunctionTypeAnnotation arg return_ ->
-            getReturnType type_ (arg :: argsAcc)
+            getReturnType return_ (arg :: argsAcc)
 
         _ ->
-            type_
+            Node.value type_

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -354,7 +354,7 @@ isNotDataLast type_ lookupTable =
                         Nothing
 
                     else
-                        case findAndGiveElementAndItsPrevious (\arg -> Node.value arg == Node.value returnType) 0 firstArg rest of
+                        case findAndGiveElementAndItsPrevious (\arg -> isTypeEqual arg returnType) 0 firstArg rest of
                             Just ( arg, argIndex, nextElement ) ->
                                 Just
                                     { argPosition = Node.range arg

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -1,0 +1,106 @@
+module DataArgumentShouldBeLast exposing (rule)
+
+{-|
+
+@docs rule
+
+-}
+
+import Elm.Syntax.Expression exposing (Expression)
+import Elm.Syntax.Node as Node exposing (Node)
+import Review.Rule as Rule exposing (Rule)
+
+
+{-| Reports... REPLACEME
+
+    config =
+        [ DataArgumentShouldBeLast.rule
+        ]
+
+
+## Fail
+
+    a =
+        "REPLACEME example to replace"
+
+
+## Success
+
+    a =
+        "REPLACEME example to replace"
+
+
+## When (not) to enable this rule
+
+This rule is useful when REPLACEME.
+This rule is not useful when REPLACEME.
+
+
+## Try it out
+
+You can try this rule out by running the following command:
+
+```bash
+elm-review --template jfmengels/elm-review-code-style/example --rules DataArgumentShouldBeLast
+```
+
+-}
+rule : Rule
+rule =
+    Rule.newProjectRuleSchema "DataArgumentShouldBeLast" initialProjectContext
+        |> Rule.withModuleVisitor moduleVisitor
+        |> Rule.withModuleContextUsingContextCreator
+            { fromProjectToModule = fromProjectToModule
+            , fromModuleToProject = fromModuleToProject
+            , foldProjectContexts = foldProjectContexts
+            }
+        -- Enable this if modules need to get information from other modules
+        -- |> Rule.withContextFromImportedModules
+        |> Rule.fromProjectRuleSchema
+
+
+type alias ProjectContext =
+    {}
+
+
+type alias ModuleContext =
+    {}
+
+
+moduleVisitor : Rule.ModuleRuleSchema schema ModuleContext -> Rule.ModuleRuleSchema { schema | hasAtLeastOneVisitor : () } ModuleContext
+moduleVisitor schema =
+    schema
+        |> Rule.withExpressionEnterVisitor expressionVisitor
+
+
+initialProjectContext : ProjectContext
+initialProjectContext =
+    {}
+
+
+fromProjectToModule : Rule.ContextCreator ProjectContext ModuleContext
+fromProjectToModule =
+    Rule.initContextCreator
+        (\projectContext ->
+            {}
+        )
+
+
+fromModuleToProject : Rule.ContextCreator ModuleContext ProjectContext
+fromModuleToProject =
+    Rule.initContextCreator
+        (\moduleContext ->
+            {}
+        )
+
+
+foldProjectContexts : ProjectContext -> ProjectContext -> ProjectContext
+foldProjectContexts new previous =
+    {}
+
+
+expressionVisitor : Node Expression -> ProjectContext -> ( List (Rule.Error {}), ProjectContext )
+expressionVisitor node context =
+    case Node.value node of
+        _ ->
+            ( [], context )

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -254,7 +254,7 @@ expressionVisitor node context =
                                     )
                             in
                             if List.length arguments == error.nbOfArguments then
-                                case createFixesForFunctionCall error arguments of
+                                case createFixesForFunctionCall context error arguments of
                                     [] ->
                                         cancelFixesAndReportError ()
 
@@ -298,8 +298,8 @@ expressionVisitor node context =
             ( [], context )
 
 
-createFixesForFunctionCall : PendingError -> List (Node Expression) -> List Fix
-createFixesForFunctionCall error arguments =
+createFixesForFunctionCall : ModuleContext -> PendingError -> List (Node Expression) -> List Fix
+createFixesForFunctionCall context error arguments =
     -- TODO Create a fix for the function call.
     -- We probably need to get more information like the position of the argument to move
     -- That needs to come from the PendingError, but we don't store it there yet.

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -143,7 +143,7 @@ declarationVisitor node context =
         Declaration.FunctionDeclaration { signature, declaration } ->
             case signature of
                 Just (Node _ type_) ->
-                    case isNotDataLast type_.typeAnnotation context.localTypes of
+                    case isNotDataLast type_.typeAnnotation context.lookupTable of
                         Just { argPosition, returnType } ->
                             ( [ Rule.error
                                     { message = "REPLACEME"
@@ -164,9 +164,9 @@ declarationVisitor node context =
             ( [], context )
 
 
-isNotDataLast : Node TypeAnnotation -> Set String -> Maybe { argPosition : Range, returnType : TypeAnnotation }
-isNotDataLast type_ localTypes =
-    case getArguments type_ localTypes [] of
+isNotDataLast : Node TypeAnnotation -> ModuleNameLookupTable -> Maybe { argPosition : Range, returnType : TypeAnnotation }
+isNotDataLast type_ lookupTable =
+    case getArguments type_ lookupTable [] of
         Nothing ->
             Nothing
 
@@ -193,11 +193,11 @@ isNotDataLast type_ localTypes =
 
 {-| Returned arguments are in the opposite order.
 -}
-getArguments : Node TypeAnnotation -> Set String -> List (Node TypeAnnotation) -> Maybe { returnType : TypeAnnotation, arguments : List (Node TypeAnnotation) }
-getArguments type_ localTypes argsAcc =
+getArguments : Node TypeAnnotation -> ModuleNameLookupTable -> List (Node TypeAnnotation) -> Maybe { returnType : TypeAnnotation, arguments : List (Node TypeAnnotation) }
+getArguments type_ lookupTable argsAcc =
     case Node.value type_ of
         TypeAnnotation.FunctionTypeAnnotation arg return_ ->
-            getArguments return_ localTypes ((Node (Node.range arg) <| Node.value <| removeRange arg) :: argsAcc)
+            getArguments return_ lookupTable ((Node (Node.range arg) <| Node.value <| removeRange arg) :: argsAcc)
 
         TypeAnnotation.Typed _ _ ->
             Just

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -400,8 +400,8 @@ isNotDataLast type_ lookupTable =
 getArguments : Node TypeAnnotation -> ModuleNameLookupTable -> List (Node TypeAnnotation) -> Maybe { returnType : Node TypeAnnotation, arguments : List (Node TypeAnnotation) }
 getArguments type_ lookupTable argsAcc =
     case Node.value type_ of
-        TypeAnnotation.FunctionTypeAnnotation arg return_ ->
-            getArguments return_ lookupTable ((Node (Node.range arg) <| Node.value <| removeRange arg) :: argsAcc)
+        TypeAnnotation.FunctionTypeAnnotation arg return ->
+            getArguments return lookupTable ((Node (Node.range arg) <| Node.value <| removeRange arg) :: argsAcc)
 
         TypeAnnotation.Typed _ _ ->
             case ModuleNameLookupTable.moduleNameFor lookupTable type_ of

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -395,6 +395,12 @@ getArguments type_ lookupTable argsAcc =
                 _ ->
                     Nothing
 
+        TypeAnnotation.Record _ ->
+            Just
+                { returnType = Node (Node.range type_) <| Node.value <| removeRange type_
+                , arguments = argsAcc
+                }
+
         _ ->
             Nothing
 

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -193,9 +193,10 @@ createFix context argPosition argIndex nextArgumentRange returnType arguments =
                     { from = { start = argPosition.start, end = nextArgumentRange.start }
                     , to = (Node.range returnType).start
                     }
-                , [ Fix.removeRange { start = { row = 5, column = 8 }, end = { row = 5, column = 14 } }
-                  , Fix.insertAt { row = 5, column = 18 } "model "
-                  ]
+                , moveCode context
+                    { from = { start = { row = 5, column = 8 }, end = { row = 5, column = 14 } }
+                    , to = { row = 5, column = 18 }
+                    }
                 ]
 
         Nothing ->

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -110,6 +110,7 @@ type alias ProjectContext =
 
 type alias ModuleContext =
     { lookupTable : ModuleNameLookupTable
+    , extractSourceCode : Range -> String
     }
 
 
@@ -127,11 +128,13 @@ initialProjectContext =
 fromProjectToModule : Rule.ContextCreator ProjectContext ModuleContext
 fromProjectToModule =
     Rule.initContextCreator
-        (\lookupTable projectContext ->
+        (\lookupTable extractSourceCode projectContext ->
             { lookupTable = lookupTable
+            , extractSourceCode = extractSourceCode
             }
         )
         |> Rule.withModuleNameLookupTable
+        |> Rule.withSourceCodeExtractor
 
 
 fromModuleToProject : Rule.ContextCreator ModuleContext ProjectContext

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -187,14 +187,14 @@ declarationVisitor node context =
 createFix : ModuleContext -> Int -> Range -> Int -> Range -> Node d -> List (Node Pattern) -> List Fix
 createFix context nbOfArguments argPosition argIndex nextArgumentRange returnType arguments =
     case listAtIndex nbOfArguments argIndex arguments of
-        Just arg ->
+        Just { rangeToMove } ->
             List.concat
                 [ moveCode context
                     { from = { start = argPosition.start, end = nextArgumentRange.start }
                     , to = (Node.range returnType).start
                     }
                 , moveCode context
-                    { from = arg
+                    { from = rangeToMove
                     , to = { row = 5, column = 18 }
                     }
                 ]
@@ -307,7 +307,7 @@ findAndGiveElementAndItsPrevious predicate index previous list =
                 findAndGiveElementAndItsPrevious predicate (index + 1) x xs
 
 
-listAtIndex : Int -> Int -> List (Node a) -> Maybe Range
+listAtIndex : Int -> Int -> List (Node a) -> Maybe { rangeToMove : Range }
 listAtIndex nbOfArguments index list =
     case list of
         [] ->
@@ -317,7 +317,9 @@ listAtIndex nbOfArguments index list =
             if index == 0 then
                 case List.head xs of
                     Just next ->
-                        Just { start = (Node.range x).start, end = (Node.range next).start }
+                        Just
+                            { rangeToMove = { start = (Node.range x).start, end = (Node.range next).start }
+                            }
 
                     Nothing ->
                         -- If there is no next element, then not all arguments are declared

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -240,7 +240,9 @@ expressionVisitor node context =
                 Just error ->
                     case ModuleNameLookupTable.moduleNameFor context.lookupTable node of
                         Just [] ->
-                            ( [], context )
+                            ( [ createError { range = error.range, fixes = [] } ]
+                            , { context | errors = Dict.remove name context.errors }
+                            )
 
                         _ ->
                             ( [], context )

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -169,7 +169,7 @@ isNotDataLast : Node TypeAnnotation -> Set String -> Maybe { argPosition : Range
 isNotDataLast type_ localTypes =
     let
         { returnType, arguments } =
-            getReturnType type_ []
+            getArguments type_ []
     in
     case arguments of
         firstArg :: rest ->
@@ -193,11 +193,11 @@ isNotDataLast type_ localTypes =
 
 {-| Returned arguments are in the opposite order.
 -}
-getReturnType : Node TypeAnnotation -> List (Node TypeAnnotation) -> { returnType : TypeAnnotation, arguments : List (Node TypeAnnotation) }
-getReturnType type_ argsAcc =
+getArguments : Node TypeAnnotation -> List (Node TypeAnnotation) -> { returnType : TypeAnnotation, arguments : List (Node TypeAnnotation) }
+getArguments type_ argsAcc =
     case Node.value type_ of
         TypeAnnotation.FunctionTypeAnnotation arg return_ ->
-            getReturnType return_ ((Node (Node.range arg) <| Node.value <| removeRange arg) :: argsAcc)
+            getArguments return_ ((Node (Node.range arg) <| Node.value <| removeRange arg) :: argsAcc)
 
         _ ->
             { returnType = Node.value (removeRange type_)

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -194,7 +194,7 @@ createFix context argPosition argIndex nextArgumentRange returnType arguments =
                     , to = (Node.range returnType).start
                     }
                 , moveCode context
-                    { from = { start = { row = 5, column = 8 }, end = { row = 5, column = 14 } }
+                    { from = arg
                     , to = { row = 5, column = 18 }
                     }
                 ]

--- a/src/DataArgumentShouldBeLast.elm
+++ b/src/DataArgumentShouldBeLast.elm
@@ -116,7 +116,7 @@ declarationVisitor node context =
                             ( [ Rule.error
                                     { message = "The data argument should be last"
                                     , details =
-                                        [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for isntance easy to pipe multiple functions working on the same type using `|>`."
+                                        [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
                                         , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
                                         ]
                                     }

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -11,6 +11,8 @@ all =
         [ test "should not report an error when there is no type annotation" <|
             \() ->
                 """module A exposing (..)
+type Msg = Msg
+type Model = Model
 update model msg =
     model
 """
@@ -19,6 +21,8 @@ update model msg =
         , test "should not report an error when the data is last" <|
             \() ->
                 """module A exposing (..)
+type Msg = Msg
+type Model = Model
 update : Msg -> Model -> Model
 update msg model =
     model
@@ -28,6 +32,8 @@ update msg model =
         , test "should report an error when the return type is present in the arguments but not as the last one" <|
             \() ->
                 """module A exposing (..)
+type Msg = Msg
+type Model = Model
 update : Model -> Msg -> Model
 update model msg =
     model
@@ -39,11 +45,14 @@ update model msg =
                             , details = [ "REPLACEME" ]
                             , under = "Model"
                             }
-                            |> Review.Test.atExactly { start = { row = 2, column = 10 }, end = { row = 2, column = 15 } }
+                            |> Review.Test.atExactly { start = { row = 4, column = 10 }, end = { row = 4, column = 15 } }
                         ]
         , test "should not report an error when the return type is not in the arguments" <|
             \() ->
                 """module A exposing (..)
+type Msg = Msg
+type Model = Model
+type OtherThing = OtherThing
 fn : OtherThing -> Msg -> Model
 fn otherThing msg =
     {}
@@ -53,7 +62,9 @@ fn otherThing msg =
         , test "should not report an error when the data is there multiple times but also as the last argument" <|
             \() ->
                 """module A exposing (..)
-add : a -> a -> a
+type Msg = Msg
+type Model = Model
+add : Model -> Model -> Model
 add a b =
     a + b
 """

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -39,6 +39,7 @@ update model msg =
                             , details = [ "REPLACEME" ]
                             , under = "Model"
                             }
+                            |> Review.Test.atExactly { start = { row = 2, column = 10 }, end = { row = 2, column = 15 } }
                         ]
         , test "should not report an error when the return type is not in the arguments" <|
             \() ->

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -246,7 +246,7 @@ fn data str =
                                 [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
                                 , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
                                 ]
-                            , under = "{ a : Int, b : Int }"
+                            , under = "{ b : Int, a : Int }"
                             }
                             |> Review.Test.whenFixed """module A exposing (main)
 fn : String -> { b : Int, a : Int } -> { a : Int, b : Int }

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -40,4 +40,13 @@ update model msg =
                             , under = "Model"
                             }
                         ]
+        , test "should not report an error when the data is there multiple times but also as the last argument" <|
+            \() ->
+                """module A exposing (..)
+add : a -> a -> a
+add a b =
+    a + b
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
         ]

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -159,6 +159,8 @@ update :
     -> Model
 update model msg =
     model
+
+value = update Msg Model
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectErrors

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -10,7 +10,7 @@ all =
     describe "DataArgumentShouldBeLast"
         [ test "should not report an error when there is no type annotation" <|
             \() ->
-                """module A exposing (..)
+                """module A exposing (main)
 type Msg = Msg
 type Model = Model
 update model msg =
@@ -20,7 +20,7 @@ update model msg =
                     |> Review.Test.expectNoErrors
         , test "should not report an error when the data is last" <|
             \() ->
-                """module A exposing (..)
+                """module A exposing (main)
 type Msg = Msg
 type Model = Model
 update : Msg -> Model -> Model
@@ -31,7 +31,7 @@ update msg model =
                     |> Review.Test.expectNoErrors
         , test "should not report an error when the data is last and also present as a different argument" <|
             \() ->
-                """module A exposing (..)
+                """module A exposing (main)
 type Msg = Msg
 type Model = Model
 update : Msg -> Model -> Model -> Model
@@ -42,7 +42,7 @@ update msg model1 model2 =
                     |> Review.Test.expectNoErrors
         , test "should report an error when the return type is present in the arguments but not as the last one" <|
             \() ->
-                """module A exposing (..)
+                """module A exposing (main)
 type Msg = Msg
 type Model = Model
 update : Model -> Msg -> Model
@@ -62,7 +62,7 @@ value = update model msg
                             , under = "Model"
                             }
                             |> Review.Test.atExactly { start = { row = 4, column = 10 }, end = { row = 4, column = 15 } }
-                            |> Review.Test.whenFixed """module A exposing (..)
+                            |> Review.Test.whenFixed """module A exposing (main)
 type Msg = Msg
 type Model = Model
 update : Msg -> Model -> Model
@@ -74,7 +74,7 @@ value = update msg model
                         ]
         , test "should report an error when the return type is present in the arguments but not as the last one (multi-line)" <|
             \() ->
-                """module A exposing (..)
+                """module A exposing (main)
 type Msg = Msg
 type Model = Model
 update :
@@ -104,7 +104,7 @@ value2 =
                             , under = "Model"
                             }
                             |> Review.Test.atExactly { start = { row = 5, column = 5 }, end = { row = 5, column = 10 } }
-                            |> Review.Test.whenFixed """module A exposing (..)
+                            |> Review.Test.whenFixed """module A exposing (main)
 type Msg = Msg
 type Model = Model
 update :
@@ -126,7 +126,7 @@ value2 =
                         ]
         , test "should not expect a fix if not all arguments are in the declaration" <|
             \() ->
-                """module A exposing (..)
+                """module A exposing (main)
 type Msg = Msg
 type Model = Model
 update :
@@ -150,7 +150,7 @@ update model =
                         ]
         , test "should not report an error when the return type is not in the arguments" <|
             \() ->
-                """module A exposing (..)
+                """module A exposing (main)
 type Msg = Msg
 type Model = Model
 type OtherThing = OtherThing
@@ -162,7 +162,7 @@ fn otherThing msg =
                     |> Review.Test.expectNoErrors
         , test "should not report an error when the data is there multiple times but also as the last argument" <|
             \() ->
-                """module A exposing (..)
+                """module A exposing (main)
 type Msg = Msg
 type Model = Model
 add : Model -> Model -> Model
@@ -173,7 +173,7 @@ add a b =
                     |> Review.Test.expectNoErrors
         , test "should not report an error when the return type is in arguments but not last, but the type is not defined in the same file" <|
             \() ->
-                """module A exposing (..)
+                """module A exposing (main)
 import Model exposing (Model)
 type Msg = Msg
 update : Model -> Msg -> Model
@@ -185,7 +185,7 @@ update model msg =
         , -- TODO We should check whether we can/should report this
           test "should not report an error when the type variables are different for the argument and the return type" <|
             \() ->
-                """module A exposing (..)
+                """module A exposing (main)
 type X a = X a
 map : X a -> (a -> b) -> X b
 map (X x) fn =

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -1,0 +1,31 @@
+module DataArgumentShouldBeLastTest exposing (all)
+
+import DataArgumentShouldBeLast exposing (rule)
+import Review.Test
+import Test exposing (Test, describe, test)
+
+
+all : Test
+all =
+    describe "DataArgumentShouldBeLast"
+        [ test "should not report an error when REPLACEME" <|
+            \() ->
+                """module A exposing (..)
+a = 1
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
+        , test "should report an error when REPLACEME" <|
+            \() ->
+                """module A exposing (..)
+a = 1
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "REPLACEME"
+                            , details = [ "REPLACEME" ]
+                            , under = "REPLACEME"
+                            }
+                        ]
+        ]

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -217,4 +217,28 @@ map (X x) fn =
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectNoErrors
+        , test "should report an error when the data type is a record" <|
+            \() ->
+                """module A exposing (main)
+fn : { a : Int } -> String -> { a : Int }
+fn data str =
+    data
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The data argument should be last"
+                            , details =
+                                [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
+                                , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
+                                ]
+                            , under = "{ a : Int }"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 6 }, end = { row = 2, column = 17 } }
+                            |> Review.Test.whenFixed """module A exposing (main)
+fn : String -> { a : Int } -> { a : Int }
+fn str data =
+    data
+"""
+                        ]
         ]

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -16,6 +16,15 @@ update model msg =
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectNoErrors
+        , test "should not report an error when the data is last" <|
+            \() ->
+                """module A exposing (..)
+update : Msg -> Model -> Model
+update msg model =
+    model
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
         , test "should report an error when the data is not last" <|
             \() ->
                 """module A exposing (..)

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -29,6 +29,17 @@ update msg model =
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectNoErrors
+        , test "should not report an error when the data is last and also present as a different argument" <|
+            \() ->
+                """module A exposing (..)
+type Msg = Msg
+type Model = Model
+update : Msg -> Model -> Model -> Model
+update msg model1 model2 =
+    model2
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
         , test "should report an error when the return type is present in the arguments but not as the last one" <|
             \() ->
                 """module A exposing (..)

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -25,7 +25,7 @@ update msg model =
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectNoErrors
-        , test "should report an error when the data is not last" <|
+        , test "should report an error when the return type is present in the arguments but not as the last one" <|
             \() ->
                 """module A exposing (..)
 update : Model -> Msg -> Model

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -40,6 +40,15 @@ update model msg =
                             , under = "Model"
                             }
                         ]
+        , test "should not report an error when the return type is not in the arguments" <|
+            \() ->
+                """module A exposing (..)
+fn : OtherThing -> Msg -> Model
+fn otherThing msg =
+    {}
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
         , test "should not report an error when the data is there multiple times but also as the last argument" <|
             \() ->
                 """module A exposing (..)

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -124,6 +124,32 @@ value2 =
         msg model
 """
                         ]
+        , test "should report an error when the return type is present in the arguments but not as the last one (more than 2 arguments)" <|
+            \() ->
+                """module A exposing (main)
+type X = X
+setChapterProgress : String -> X -> Int -> X
+setChapterProgress string x int =
+    X
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The data argument should be last"
+                            , details =
+                                [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
+                                , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
+                                ]
+                            , under = "X"
+                            }
+                            |> Review.Test.atExactly { start = { row = 3, column = 32 }, end = { row = 3, column = 33 } }
+                            |> Review.Test.whenFixed """module A exposing (main)
+type X = X
+setChapterProgress : String -> Int -> X -> X
+setChapterProgress string int x =
+    X
+"""
+                        ]
         , test "should not expect a fix if not all arguments are in the declaration" <|
             \() ->
                 """module A exposing (main)

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -86,12 +86,12 @@ update model msg =
 
 value =
     update
-        msg
         model
+        msg
 
 value2 =
-    update msg
-        model
+    update model
+        msg
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectErrors
@@ -116,12 +116,12 @@ update msg model =
 
 value =
     update
-        model
         msg
+        model
 
 value2 =
-    update model
-        msg
+    update
+        msg model
 """
                         ]
         , test "should not expect a fix if not all arguments are in the declaration" <|

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -124,6 +124,30 @@ value2 =
         msg
 """
                         ]
+        , test "should not expect a fix if not all arguments are in the declaration" <|
+            \() ->
+                """module A exposing (..)
+type Msg = Msg
+type Model = Model
+update :
+    Model
+    -> Msg
+    -> Model
+update model =
+    fn
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The data argument should be last"
+                            , details =
+                                [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
+                                , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
+                                ]
+                            , under = "Model"
+                            }
+                            |> Review.Test.atExactly { start = { row = 5, column = 5 }, end = { row = 5, column = 10 } }
+                        ]
         , test "should not report an error when the return type is not in the arguments" <|
             \() ->
                 """module A exposing (..)

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -148,6 +148,30 @@ update model =
                             }
                             |> Review.Test.atExactly { start = { row = 5, column = 5 }, end = { row = 5, column = 10 } }
                         ]
+        , test "should not expect a fix if the function is exposed" <|
+            \() ->
+                """module A exposing (update)
+type Msg = Msg
+type Model = Model
+update :
+    Model
+    -> Msg
+    -> Model
+update model msg =
+    model
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The data argument should be last"
+                            , details =
+                                [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
+                                , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
+                                ]
+                            , under = "Model"
+                            }
+                            |> Review.Test.atExactly { start = { row = 5, column = 5 }, end = { row = 5, column = 10 } }
+                        ]
         , test "should not report an error when the return type is not in the arguments" <|
             \() ->
                 """module A exposing (main)

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -73,7 +73,7 @@ add a b =
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectNoErrors
-        , test "should report an error when the return type is in arguments but not last, but the type is not defined in the same file" <|
+        , test "should not report an error when the return type is in arguments but not last, but the type is not defined in the same file" <|
             \() ->
                 """module A exposing (..)
 import Model exposing (Model)

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -48,6 +48,8 @@ type Model = Model
 update : Model -> Msg -> Model
 update model msg =
     model
+
+value = update model msg
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectErrors
@@ -66,9 +68,11 @@ type Model = Model
 update : Msg -> Model -> Model
 update msg model =
     model
+
+value = update msg model
 """
                         ]
-        , test "should report an error when the return type is present in the arguments but not as the last one (multi-line signature)" <|
+        , test "should report an error when the return type is present in the arguments but not as the last one (multi-line)" <|
             \() ->
                 """module A exposing (..)
 type Msg = Msg
@@ -79,6 +83,15 @@ update :
     -> Model
 update model msg =
     model
+
+value =
+    update
+        msg
+        model
+
+value2 =
+    update msg
+        model
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectErrors
@@ -100,6 +113,15 @@ update :
     -> Model
 update msg model =
     model
+
+value =
+    update
+        model
+        msg
+
+value2 =
+    update model
+        msg
 """
                         ]
         , test "should not report an error when the return type is not in the arguments" <|

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -41,8 +41,11 @@ update model msg =
                     |> Review.Test.run rule
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "REPLACEME"
-                            , details = [ "REPLACEME" ]
+                            { message = "The data argument should be last"
+                            , details =
+                                [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for isntance easy to pipe multiple functions working on the same type using `|>`."
+                                , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
+                                ]
                             , under = "Model"
                             }
                             |> Review.Test.atExactly { start = { row = 4, column = 10 }, end = { row = 4, column = 15 } }

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -60,6 +60,13 @@ update model msg =
                             , under = "Model"
                             }
                             |> Review.Test.atExactly { start = { row = 4, column = 10 }, end = { row = 4, column = 15 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+type Msg = Msg
+type Model = Model
+update : Msg -> Model -> Model
+update msg model =
+    model
+"""
                         ]
         , test "should not report an error when the return type is not in the arguments" <|
             \() ->

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -8,24 +8,27 @@ import Test exposing (Test, describe, test)
 all : Test
 all =
     describe "DataArgumentShouldBeLast"
-        [ test "should not report an error when REPLACEME" <|
+        [ test "should not report an error when there is no type annotation" <|
             \() ->
                 """module A exposing (..)
-a = 1
+update model msg =
+    model
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectNoErrors
-        , test "should report an error when REPLACEME" <|
+        , test "should report an error when the data is not last" <|
             \() ->
                 """module A exposing (..)
-a = 1
+update : Model -> Msg -> Model
+update model msg =
+    model
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "REPLACEME"
                             , details = [ "REPLACEME" ]
-                            , under = "REPLACEME"
+                            , under = "Model"
                             }
                         ]
         ]

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -43,7 +43,7 @@ update model msg =
                         [ Review.Test.error
                             { message = "The data argument should be last"
                             , details =
-                                [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for isntance easy to pipe multiple functions working on the same type using `|>`."
+                                [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
                                 , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
                                 ]
                             , under = "Model"

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -70,4 +70,15 @@ add a b =
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectNoErrors
+        , test "should report an error when the return type is in arguments but not last, but the type is not defined in the same file" <|
+            \() ->
+                """module A exposing (..)
+import Model exposing (Model)
+type Msg = Msg
+update : Model -> Msg -> Model
+update model msg =
+    model
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
         ]

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -220,7 +220,7 @@ map (X x) fn =
         , test "should report an error when the data type is a record" <|
             \() ->
                 """module A exposing (main)
-fn : { a : Int } -> String -> { a : Int }
+fn : { b : Int, a : Int } -> String -> { a : Int, b : Int }
 fn data str =
     data
 """
@@ -232,11 +232,10 @@ fn data str =
                                 [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
                                 , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
                                 ]
-                            , under = "{ a : Int }"
+                            , under = "{ a : Int, b : Int }"
                             }
-                            |> Review.Test.atExactly { start = { row = 2, column = 6 }, end = { row = 2, column = 17 } }
                             |> Review.Test.whenFixed """module A exposing (main)
-fn : String -> { a : Int } -> { a : Int }
+fn : String -> { b : Int, a : Int } -> { a : Int, b : Int }
 fn str data =
     data
 """

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -84,4 +84,15 @@ update model msg =
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectNoErrors
+        , -- TODO We should check whether we can/should report this
+          test "should not report an error when the type variables are different for the argument and the return type" <|
+            \() ->
+                """module A exposing (..)
+type X a = X a
+map : X a -> (a -> b) -> X b
+map (X x) fn =
+    X (fn x)
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
         ]

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -254,4 +254,13 @@ fn str data =
     data
 """
                         ]
+        , test "should not report an error when the data type is a record but different in args" <|
+            \() ->
+                """module A exposing (main)
+fn : { b : Int, a : String } -> String -> { a : Int, b : Int }
+fn data str =
+    data
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
         ]

--- a/tests/DataArgumentShouldBeLastTest.elm
+++ b/tests/DataArgumentShouldBeLastTest.elm
@@ -68,6 +68,40 @@ update msg model =
     model
 """
                         ]
+        , test "should report an error when the return type is present in the arguments but not as the last one (multi-line signature)" <|
+            \() ->
+                """module A exposing (..)
+type Msg = Msg
+type Model = Model
+update :
+    Model
+    -> Msg
+    -> Model
+update model msg =
+    model
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The data argument should be last"
+                            , details =
+                                [ "In Elm, it is common in functions that return the same type as one of the arguments to have that argument be the last. This makes it for instance easy to compose operations using `|>` or `>>`."
+                                , "Example: instead of `update : Model -> Msg -> Model`, it is more idiomatic to have `update : Msg -> Model -> Model`"
+                                ]
+                            , under = "Model"
+                            }
+                            |> Review.Test.atExactly { start = { row = 5, column = 5 }, end = { row = 5, column = 10 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+type Msg = Msg
+type Model = Model
+update :
+    Msg
+    -> Model
+    -> Model
+update msg model =
+    model
+"""
+                        ]
         , test "should not report an error when the return type is not in the arguments" <|
             \() ->
                 """module A exposing (..)


### PR DESCRIPTION
I made a rule to make sure that function’s arguments are “data last”: if a function takes an argument that is the same as the return type, then that argument should be the last one. Example: `update : Msg -> Model -> Model` instead of `update : Model -> Msg -> Model`.

```
elm-review --template jfmengels/elm-review-code-style/preview#data-argument-last --rules DataArgumentShouldBeLast
```

The plan is for this to be autofixable when all function calls are called explicitly with all their arguments (and not fix it otherwise). I’m not sure how to catch things like: `update : Model -> Msg -> ( Model, Cmd Msg )` yet.

I'm still trying to figure out the boundaries for such a rule. I quickly noticed that functions like the ones you were showing should probably not have this constraint, so my current delimitation is to only do it on functions where the return type is defined in the same file. So far from only a quick glance that seems to give good results (no false positives) on my work project. I'll probably try to extend it to types defined in the project, not just the local file, and see what the results are.

@lue-bird made the suggestion to enforce this on any function that is in a "alter"/"manipulate"/"modify" section:
```elm
module X exposing (...)
{-|
## create
@docs repeatConcat, fromList
## alter
@docs take, drop, pop, push
## transform
@docs toList
-}

take : X a -> Int -> X a -- reported

repeatConcat : X a -> Int -> X a -- not reported
```
which seems to hold for core packages, and other packages like https://dark.elm.dmy.fr/packages/owanturist/elm-avl-dict/latest/AVL-Dict#manipulation

---

Another limitation I've set so far as that the argument has to be the exact same as the return type. That means that if type variables are different, then the function will not be reported

```elm
-- Currently not reported
map : X a -> (a -> b) -> X b
```

It's probably worth looking at whether this limitation should be removed. I mostly have this limitation for now because it was easier to implement.